### PR TITLE
Feature/description fields and models

### DIFF
--- a/packages/app/components/jsonschemaform/fields/DescriptionField.tsx
+++ b/packages/app/components/jsonschemaform/fields/DescriptionField.tsx
@@ -23,7 +23,7 @@ function DescriptionField(props) {
                 </Tooltip>
             )}
         >
-            <FaQuestionCircle />
+            <FaQuestionCircle className="mr-2" />
         </OverlayTrigger>
     )
 }

--- a/packages/app/pages/404.tsx
+++ b/packages/app/pages/404.tsx
@@ -1,0 +1,34 @@
+import { Breadcrumbs, Breadcrumb } from 'components/breadcrumbs'
+import PageTitle from 'components/page-title'
+
+export default function Custom404() {
+    const pageTitle = '404 - Page Not Found'
+
+    return (
+        <>
+            <PageTitle title={pageTitle} />
+
+            <Breadcrumbs>
+                <Breadcrumb title={pageTitle} />
+            </Breadcrumbs>
+
+            <div className="d-flex align-items-center justify-content-center vh-100">
+                <div className="text-center">
+                    <h1 className="display-1 fw-bold">404</h1>
+
+                    <p className="fs-3">
+                        <span className="text-danger">Sorry!</span> Page not found.
+                    </p>
+
+                    <p className="lead">
+                        The page you&apos;re looking for doesn&apos;t exist.
+                    </p>
+
+                    <a href="/meditor" className="btn btn-primary">
+                        Return to Homepage
+                    </a>
+                </div>
+            </div>
+        </>
+    )
+}

--- a/packages/app/utils/errors.ts
+++ b/packages/app/utils/errors.ts
@@ -78,3 +78,22 @@ export function apiError(error: Error | HttpException, response: NextApiResponse
         error: safeError.message,
     })
 }
+
+/**
+ * compare an unknown error to see if it matches an expected error code
+ *
+ * ex. errorMatchesErrorCode(myError, ErrorCode.NotFound)
+ */
+export function errorMatchesErrorCode(
+    error: Error | HttpException | undefined,
+    errorCode: ErrorCode
+) {
+    return error && error instanceof HttpException && error.cause.code === errorCode
+}
+
+/**
+ * helper function as this is a fairly common use-case
+ */
+export function isNotFoundError(error?: Error | HttpException) {
+    return errorMatchesErrorCode(error, ErrorCode.NotFound)
+}


### PR DESCRIPTION
A few cleanup actions...

1) a failure to get a model will throw a javascript error and break the page (this happens if the model doesn't exist OR there was a problem fetching it, i.e. database was down) See this live example: https://lb.gesdisc.eosdis.nasa.gov/meditor/foo

2) Adding a 404 page

3) Slight margin on the description field to handle boolean fields. See "Report to EMS" field in the following screenshot 

![Screenshot 2023-04-10 at 10 50 23 AM](https://user-images.githubusercontent.com/1513070/230974330-f6a1172c-52b1-4d7c-bf5f-78344cf0d25b.png)
