### PR TITLE
Clear document publication statuses before publish

### DIFF
--- a/packages/app/documents/db.ts
+++ b/packages/app/documents/db.ts
@@ -263,7 +263,7 @@ class DocumentsDb {
             },
             {
                 $set: {
-                    'x-meditor.publishedTo': {},
+                    'x-meditor.publishedTo': [],
                 },
             }
         )

--- a/packages/app/documents/db.ts
+++ b/packages/app/documents/db.ts
@@ -1,5 +1,5 @@
 import type { Db } from 'mongodb'
-import { ObjectID } from 'mongodb'
+import { ObjectId } from 'mongodb'
 import type { User } from '../auth/types'
 import getDb, { makeSafeObjectIDs } from '../lib/mongodb'
 import type {
@@ -253,6 +253,22 @@ class DocumentsDb {
         return firstPublicationsEntry['x-meditor'].publishedTo
     }
 
+    /**
+     * removes all document publications for a given Mongo document _id
+     */
+    async removeAllDocumentPublications(documentId: string, modelName: string) {
+        await this.#db.collection(modelName).updateOne(
+            {
+                _id: new ObjectId(documentId),
+            },
+            {
+                $set: {
+                    'x-meditor.publishedTo': {},
+                },
+            }
+        )
+    }
+
     async getDocumentsForModel(
         modelName: string,
         searchOptions: DocumentsSearchOptions,
@@ -394,7 +410,7 @@ class DocumentsDb {
         await this.#db.collection(document['x-meditor'].model).updateOne(
             {
                 // updating an existing document, use the _id instead of the documentTitle, this ensures no race conditions where two users are creating/updating simultaneously
-                _id: new ObjectID(document._id),
+                _id: new ObjectId(document._id),
             },
             updateQuery
         )
@@ -459,7 +475,7 @@ class DocumentsDb {
         modelName: string
     ): Promise<Document> {
         const comment = await this.#db.collection(modelName).findOne({
-            _id: new ObjectID(documentId),
+            _id: new ObjectId(documentId),
         })
 
         return makeSafeObjectIDs(comment)

--- a/packages/app/documents/service.ts
+++ b/packages/app/documents/service.ts
@@ -573,8 +573,14 @@ export async function safelyPublishDocumentChangeToQueue(
 ) {
     try {
         if (isPublishableWithWorkflowSupport(model, state)) {
+            const documentsDb = await getDocumentsDb()
+
             // turns "Data Release" into "Data-Release"
             const channelName = model.name.replace(/ /g, '-')
+
+            // before we publish, first delete existing publication statuses
+            //? if we don't, user may be confused and think the old publication statuses still apply
+            await documentsDb.removeAllDocumentPublications(document._id, model.name)
 
             // publish the document state change to the right channel
             //? One or more subscribers can be subscribed to this particular channel, these are external subscribers


### PR DESCRIPTION
**Problem**

When moving a document from "Draft" to "Published", we don't clear out the old publication statuses (whether the document published successfully or not). 

This is confusing to users as they may see errors that were happening on the TEST website and think that the PROD website is having the same error.

This is usually not a problem as publishing happens very fast. However if the website is down, the old publication statuses can be visible for awhile.

**Solution**

When publishing, always start with zero publication statuses.