### PR TITLE
chore(Docker): restrict port binding to local network

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -32,7 +32,7 @@ services:
     env_file:
       - .env
     ports:
-      - "4000:4000"
+      - "127.0.0.1:4000:4000"
     volumes:
       - ./packages/app:/usr/src/app
       - /usr/src/app/node_modules
@@ -43,7 +43,7 @@ services:
     env_file:
       - .env
     ports:
-      - "3030:3030"
+      - "127.0.0.1:3030:3030"
 
   legacy-api:
     container_name: meditor_legacy-api
@@ -60,15 +60,15 @@ services:
     volumes:
       - ./mongo-data:/data/db
     ports:
-      - "27018:27017"
+      - "127.0.0.1:27018:27017"
 
   nats:
     container_name: meditor_nats
     volumes:
       - ./nats-data:/nats/data
     ports:
-      - 4222:4222
-      - 8222:8222
+      - "127.0.0.1:4222:4222"
+      - "127.0.0.1:8222:8222"
 
   monitor:
     container_name: meditor_monitor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
 
   proxy:
     ports:
-      - "80:8080"
+      - "127.0.0.1:80:8080"
     depends_on:
       - legacy-api
       - nats
@@ -54,11 +54,10 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/lib/docker/volumes:/var/lib/docker/volumes
     ports:
-      - "9001:9001"
+      - "127.0.0.1:9001:9001"
 
 volumes:
   monitor-data:
-
 
 networks:
   default:


### PR DESCRIPTION
Per our internal conversation with security, we're binding these ports to localhost to prevent exposing a non-https service to the public internet.