### PR TITLE
Implement Github Actions to require passing Jest tests before PR merge is allowed

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,29 @@
+name: Continuous Integration
+
+# This action works with pull requests and pushes to branches other than main
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # Make sure the actual branch is checked out when running on pull requests
+          ref: ${{ github.head_ref }}
+          # This is important to fetch the changes to the previous commit
+          fetch-depth: 0
+
+      - name: Prettify code
+        uses: creyD/prettier_action@v4.3
+        with:
+          dry: True
+          # This part is also where you can pass other options, for example:
+          #prettier_options:
+          only_changed: True

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout latest code from branch
         uses: actions/checkout@v3
         with:
           # Make sure the actual branch is checked out when running on pull requests
@@ -20,17 +20,26 @@ jobs:
           # This is important to fetch the changes to the previous commit
           fetch-depth: 0
 
-      - name: Install dependencies
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: packages/app/node_modules
+          # cache is reset if any new dependencies are installed
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install package dependencies (package.json)
         working-directory: ./packages/app
-        run: npm install
+        # don't install if we can reuse the cached node_modules
+        if: steps.cache-nodemodules.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Run tests
         working-directory: ./packages/app
         run: npm run test
-#- name: Prettify code
-#uses: creyD/prettier_action@v4.3
-##with:
-#dry: True
-# This part is also where you can pass other options, for example:
-#prettier_options:#
-#only_changed: True

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -8,7 +8,7 @@ on:
       - main
 
 jobs:
-  prettier:
+  app-jest:
     runs-on: ubuntu-latest
 
     steps:
@@ -20,10 +20,17 @@ jobs:
           # This is important to fetch the changes to the previous commit
           fetch-depth: 0
 
-      - name: Prettify code
-        uses: creyD/prettier_action@v4.3
-        with:
-          dry: True
-          # This part is also where you can pass other options, for example:
-          #prettier_options:
-          only_changed: True
+      - name: Install dependencies
+        working-directory: ./packages/app
+        run: npm install
+
+      - name: Run tests
+        working-directory: ./packages/app
+        run: npm run test
+#- name: Prettify code
+#uses: creyD/prettier_action@v4.3
+##with:
+#dry: True
+# This part is also where you can pass other options, for example:
+#prettier_options:#
+#only_changed: True

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -10,6 +10,14 @@ on:
 jobs:
   app-jest:
     runs-on: ubuntu-latest
+    name: app-node-${{ matrix.node }}
+    strategy:
+      matrix:
+        node: [16, 20] # Node versions to test against
+      fail-fast: true
+    defaults:
+      run:
+        working-directory: app
 
     steps:
       - name: Checkout latest code from branch
@@ -20,17 +28,15 @@ jobs:
           # Fetch only the changes to the previous commit
           fetch-depth: 0
 
-      - name: Setup Node and npm cache
+      - name: Setup NodeJS ${{ matrix.node }}
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: ${{ matrix.node }}
           cache: "npm"
-          cache-dependency-path: packages/app/package-lock.json
+          cache-dependency-path: "packages/app"
 
-      - name: Install package dependencies (npm install)
-        working-directory: ./packages/app
-        run: npm ci
+      - name: Install package dependencies
+        run: npm install
 
       - name: Run tests
-        working-directory: ./packages/app
         run: npm run test

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -13,7 +13,7 @@ jobs:
     name: app-node-${{ matrix.node }}
     strategy:
       matrix:
-        node: [16, 20] # Node versions to test against
+        node: [16] # One or more Node versions to test against
       fail-fast: true
     defaults:
       run:

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
     defaults:
       run:
-        working-directory: app
+        working-directory: packages/app
 
     steps:
       - name: Checkout latest code from branch

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -17,27 +17,18 @@ jobs:
         with:
           # Make sure the actual branch is checked out when running on pull requests
           ref: ${{ github.head_ref }}
-          # This is important to fetch the changes to the previous commit
+          # Fetch only the changes to the previous commit
           fetch-depth: 0
 
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
+      - name: Setup Node and npm cache
+        uses: actions/setup-node@v3
         with:
-          path: packages/app/node_modules
-          # cache is reset if any new dependencies are installed
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          node-version: 16
+          cache: "npm"
+          cache-dependency-path: packages/app/package-lock.json
 
-      - name: Install package dependencies (package.json)
+      - name: Install package dependencies (npm install)
         working-directory: ./packages/app
-        # don't install if we can reuse the cached node_modules
-        if: steps.cache-nodemodules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Run tests

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -15,9 +15,6 @@ jobs:
       matrix:
         node: [16] # One or more Node versions to test against
       fail-fast: true
-    defaults:
-      run:
-        working-directory: packages/app
 
     steps:
       - name: Checkout latest code from branch
@@ -33,10 +30,12 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: "npm"
-          cache-dependency-path: "packages/app"
+          cache-dependency-path: packages/app/package-lock.json
 
       - name: Install package dependencies
+        working-directory: packages/app
         run: npm install
 
       - name: Run tests
+        working-directory: packages/app
         run: npm run test

--- a/packages/app/email-notifications/__tests__/__snapshots__/email-notifications.test.ts.snap
+++ b/packages/app/email-notifications/__tests__/__snapshots__/email-notifications.test.ts.snap
@@ -8,7 +8,7 @@ An action is required to transition the document to one of the [Draft, Approved]
   "cc": Array [
     "\\"Eggs User\\" <eggs@mock.nasa.gov>",
   ],
-  "createdOn": "2022-01-01T00:00:00.000Z",
+  "createdOn": "2022-01-01T05:00:00.000Z",
   "link": Object {
     "label": "How do I?",
     "url": "http://localhost/meditor/FAQs/How%20do%20I%3F",

--- a/packages/app/email-notifications/__tests__/__snapshots__/email-notifications.test.ts.snap
+++ b/packages/app/email-notifications/__tests__/__snapshots__/email-notifications.test.ts.snap
@@ -8,7 +8,7 @@ An action is required to transition the document to one of the [Draft, Approved]
   "cc": Array [
     "\\"Eggs User\\" <eggs@mock.nasa.gov>",
   ],
-  "createdOn": "2022-01-01T05:00:00.000Z",
+  "createdOn": "2022-01-01T00:00:00.000Z",
   "link": Object {
     "label": "How do I?",
     "url": "http://localhost/meditor/FAQs/How%20do%20I%3F",

--- a/packages/app/email-notifications/__tests__/email-notifications.test.ts
+++ b/packages/app/email-notifications/__tests__/email-notifications.test.ts
@@ -341,7 +341,7 @@ describe('Email Notifications', () => {
     })
 
     describe('constructEmailMessageForStateChange', () => {
-        let mockDate = new Date(2022, 0, 1)
+        let mockDate = new Date(2022, 0, 1, 0, 0, 0, 0)
         let dateSpy
         let model
         let currentEdge

--- a/packages/app/jest.config.js
+++ b/packages/app/jest.config.js
@@ -2,6 +2,8 @@
 const tsPreset = require('ts-jest/jest-preset')
 const mongoPreset = require('@shelf/jest-mongodb/jest-preset')
 
+process.env.TZ = 'GMT' // ensure all tests use GMT time, both locally and on CI servers
+
 const jestOverwrites = {
     testEnvironment: 'node',
     watchPathIgnorePatterns: [


### PR DESCRIPTION
As the title states, adds Github actions to the project.

This will do a fresh `npm install` and run Jest tests against Node 16. Any failures will block the PR from being merged until Jest tests are passing again.

See the bottom of this PR page for a "Successful checks" area. That is the Github actions output. It should say "All checks have passed".