### PR TITLE
Feature/GUUI 3064 document the business rules about how emails are being sent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "meditor",
+  "version": "1.9.12",
+  "lockfileVersion": 1
+}

--- a/packages/app/email-notifications/__tests__/__snapshots__/email-notifications.test.ts.snap
+++ b/packages/app/email-notifications/__tests__/__snapshots__/email-notifications.test.ts.snap
@@ -6,7 +6,7 @@ Object {
 
 An action is required to transition the document to one of the [Draft, Approved] states. <p><strong>Latest Comment:</strong></p>",
   "cc": Array [
-    "\\"Eggs User\\" <eggs@mock.nasa.gov>",
+    "\\"Bacon User\\" <bacon@mock.nasa.gov>",
   ],
   "createdOn": "2022-01-01T00:00:00.000Z",
   "link": Object {
@@ -15,7 +15,8 @@ An action is required to transition the document to one of the [Draft, Approved]
   },
   "subject": "FAQs document is now Under Review",
   "to": Array [
-    "\\"Bacon User\\" <bacon@mock.nasa.gov>",
+    "\\"Eggs User\\" <eggs@mock.nasa.gov>",
+    "\\"Hashbrowns User\\" <hashbrowns@mock.nasa.gov>",
   ],
 }
 `;

--- a/packages/app/email-notifications/__tests__/email-notifications.test.ts
+++ b/packages/app/email-notifications/__tests__/email-notifications.test.ts
@@ -132,7 +132,7 @@ describe('Email Notifications', () => {
         ${'Init'}         | ${''}             | ${'FAQs'}   | ${modifyReviewPublishWorkflow} | ${[]}
         ${'Draft'}        | ${'Init'}         | ${'FAQs'}   | ${modifyReviewPublishWorkflow} | ${[]}
         ${'Under Review'} | ${'Draft'}        | ${'FAQs'}   | ${modifyReviewPublishWorkflow} | ${['eggs', 'hashbrowns']}
-        ${'Draft'}        | ${'Under Review'} | ${'FAQs'}   | ${modifyReviewPublishWorkflow} | ${['bacon']}
+        ${'Draft'}        | ${'Under Review'} | ${'FAQs'}   | ${modifyReviewPublishWorkflow} | ${['eggs', 'hashbrowns']}
         ${'Approved'}     | ${'Under Review'} | ${'FAQs'}   | ${modifyReviewPublishWorkflow} | ${['grits', 'gravy']}
         ${'Under Review'} | ${'Approved'}     | ${'FAQs'}   | ${modifyReviewPublishWorkflow} | ${['eggs', 'hashbrowns']}
         ${'Published'}    | ${'Approved'}     | ${'FAQs'}   | ${modifyReviewPublishWorkflow} | ${['grits', 'gravy']}

--- a/packages/app/workflows/__tests__/__fixtures__/edit-review-publish.json
+++ b/packages/app/workflows/__tests__/__fixtures__/edit-review-publish.json
@@ -81,35 +81,40 @@
             "source": "Draft",
             "target": "Under Review",
             "label": "Submit for Review",
-            "notify": true
+            "notify": true,
+            "notifyRoles": "Reviewer"
         },
         {
             "role": "Reviewer",
             "source": "Under Review",
             "target": "Approved",
             "label": "Approve for Publication",
-            "notify": true
+            "notify": true,
+            "notifyRoles": "Publisher"
         },
         {
             "role": "Publisher",
             "source": "Approved",
             "target": "Published",
             "label": "Publish",
-            "notify": true
+            "notify": true,
+            "notifyRoles": "Publisher"
         },
         {
             "role": "Reviewer",
             "source": "Under Review",
             "target": "Draft",
             "label": "Needs more Work",
-            "notify": true
+            "notify": true,
+            "notifyRoles": "Reviewer"
         },
         {
             "role": "Publisher",
             "source": "Approved",
             "target": "Under Review",
             "label": "I don't like it",
-            "notify": true
+            "notify": true,
+            "notifyRoles": "Reviewer"
         }
     ],
     "x-meditor": {

--- a/packages/app/workflows/__tests__/__fixtures__/modify-review-publish.json
+++ b/packages/app/workflows/__tests__/__fixtures__/modify-review-publish.json
@@ -107,7 +107,7 @@
             "target": "Draft",
             "label": "Needs more work",
             "notify": true,
-            "notifyRoles": "Author"
+            "notifyRoles": "Reviewer"
         },
         {
             "role": "Reviewer",
@@ -115,7 +115,7 @@
             "target": "Approved",
             "label": "Approve publication",
             "notify": true,
-            "notifyRoles": "Reviewer"
+            "notifyRoles": "Publisher"
         },
         {
             "role": "Publisher",
@@ -131,7 +131,7 @@
             "target": "Under Review",
             "label": "I don't like it!",
             "notify": true,
-            "notifyRoles": "Publisher"
+            "notifyRoles": "Reviewer"
         },
         {
             "role": "Publisher",

--- a/packages/app/workflows/__tests__/__fixtures__/modify-review-publish.json
+++ b/packages/app/workflows/__tests__/__fixtures__/modify-review-publish.json
@@ -98,35 +98,40 @@
             "source": "Draft",
             "target": "Under Review",
             "label": "Submit for review",
-            "notify": true
+            "notify": true,
+            "notifyRoles": "Reviewer"
         },
         {
             "role": "Reviewer",
             "source": "Under Review",
             "target": "Draft",
             "label": "Needs more work",
-            "notify": true
+            "notify": true,
+            "notifyRoles": "Author"
         },
         {
             "role": "Reviewer",
             "source": "Under Review",
             "target": "Approved",
             "label": "Approve publication",
-            "notify": true
+            "notify": true,
+            "notifyRoles": "Reviewer"
         },
         {
             "role": "Publisher",
             "source": "Approved",
             "target": "Published",
             "label": "Publish",
-            "notify": true
+            "notify": true,
+            "notifyRoles": "Publisher"
         },
         {
             "role": "Publisher",
             "source": "Approved",
             "target": "Under Review",
             "label": "I don't like it!",
-            "notify": true
+            "notify": true,
+            "notifyRoles": "Publisher"
         },
         {
             "role": "Publisher",


### PR DESCRIPTION
This PR has changes for email notification test fixtures which contains notifyRoles to notify specific roles for document state change, also updated test snapshot for email-notification to receive accurate notification. 

For reference here is the document of email notification rules: [Business rules about email notification from Meditor-notifier](https://docs.google.com/document/d/16YaoejJV7l7puZ6GpRq4XwNuiatjmCw0nF3Dj3LM5p0/edit) 

To Test:
run test inside email-notifications. should pass all test