### PR TITLE
fix(app): adjust scroll and padding

### DIFF
--- a/packages/app/components/document/document-panel.module.css
+++ b/packages/app/components/document/document-panel.module.css
@@ -9,7 +9,7 @@
     transition: transform 0.1s linear;
     margin-right: 12px;
     bottom: 60px;
-    overscroll-behavior-y: contain;
+    overscroll-behavior-block: contain;
     padding-block-end: 6rem;
 }
 

--- a/packages/app/components/document/document-panel.module.css
+++ b/packages/app/components/document/document-panel.module.css
@@ -9,6 +9,8 @@
     transition: transform 0.1s linear;
     margin-right: 12px;
     bottom: 60px;
+    overscroll-behavior-y: contain;
+    padding-block-end: 6rem;
 }
 
 .panelLarge {


### PR DESCRIPTION
The original bug that prompted this probably had to do something with the Document Panel's positioning being too far down the page, which has been fixed in another PR. This PR adds some padding to the bottom of the Document Panel and prevents scroll chaining so that users can freely scroll any overflow content in the panel without scrolling the rest of the page.