### PR TITLE
run formatter one package at a time

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,6 +11,7 @@ jobs:
       contents: write
 
     strategy:
+      max-parallel: 1
       matrix:
         directory: ["packages/app", "packages/docs", "packages/proxy"]
 


### PR DESCRIPTION
Seems that the matrix strategy doesn't work well with parallel jobs. The formatting action is failing on the latest PR when running in parallel, but seems to work with one job at a time. Going to look more into this but this PR just limits it to 1 at a time