### PR TITLE
fix: enforce validation on jsonpath

### DIFF
--- a/packages/app/components/jsonschemaform/jsonschemaform.tsx
+++ b/packages/app/components/jsonschemaform/jsonschemaform.tsx
@@ -105,6 +105,11 @@ export default JsonSchemaForm
 //* Validate custom widgets here because of this issue: https://github.com/rjsf-team/react-jsonschema-form/issues/2718
 function validateCustomWidgets(formData: any, errors: FormValidation) {
     formData.templates?.forEach((template: any, index: number) => {
+        //* Another schema may have a `templates` property, but not intend it for macros. This attempts to guard against that.
+        if (!('jsonpath' in template)) {
+            return
+        }
+
         //* Macro templates can reference either the schema or layout (see macro ReadMe).
         const isValid = [
             validatePath(template.jsonpath, JSON.parse(formData.schema || '{}')),

--- a/packages/app/components/jsonschemaform/jsonschemaform.tsx
+++ b/packages/app/components/jsonschemaform/jsonschemaform.tsx
@@ -1,4 +1,4 @@
-import Form, { FormValidation } from '@rjsf/core'
+import Form from '@rjsf/core'
 import jp from 'jsonpath'
 import filter from 'lodash/filter'
 import isEqual from 'lodash/isEqual'
@@ -7,6 +7,7 @@ import { useEffect, useRef } from 'react'
 import fields from './fields/'
 import templates from './templates/'
 import widgets from './widgets/'
+import type { FormValidation } from '@rjsf/core'
 
 const JsonSchemaForm = ({
     schema,

--- a/packages/app/macros/ReadMe.md
+++ b/packages/app/macros/ReadMe.md
@@ -13,6 +13,8 @@ Macros are made with an internal DSL for running queries written into a model's 
 }
 ```
 
+The `jsonpath` can target either a model's `layout` or `schema`, with `schema` targets looking like `$.properties.{sub-properties}`. If targeting the layout, we're building something like a list of suggestions where the user can pick a suggestion or enter their own. If targeting the schema, the user must pick one of the presented options.
+
 The list macro defined above will generate a list of unique titles from within the `Keywords` collection in the database, replacing the data on the model at the `jsonpath` with its return value. In this case, `model.schema.properties.tags.items.enum` would have a value of `'placeholder'` initially, then get replaced with a list of unique news titles. This can be used in the UI to create comboboxes, selects, etc. Other macros follow this general syntax of `{macro name} {macro argument}`.
 
 ## 'list'


### PR DESCRIPTION
This code change ensures that the Template's `jsonpath` matches a valid path in either the form's schema or layout.