### PR TITLE
fix: allow spaces in document filter

### DIFF
--- a/packages/app/components/search/search-status-bar.tsx
+++ b/packages/app/components/search/search-status-bar.tsx
@@ -99,10 +99,10 @@ const SearchStatusBar = ({
                             value={searchOptions.filter}
                             onChange={e => onFilterChange(e.target.value)}
                         >
-                            <option value=""></option>
+                            <option value="">Show All States</option>
 
                             {states.map(state => (
-                                <option key={state} value={`state:${state}`}>
+                                <option key={state} value={`state:"${state}"`}>
                                     {state}
                                 </option>
                             ))}


### PR DESCRIPTION
This commit also adds an accessible name of "Show All States" to the default-selected option.

![show-all-states](https://github.com/nasa/gesdisc-meditor/assets/2887467/a5ac2c28-1342-4a5a-8086-dccae1c961df)
