### PR TITLE
Fix/comments

### DIFF
--- a/packages/app/components/document/document-comments.tsx
+++ b/packages/app/components/document/document-comments.tsx
@@ -11,7 +11,7 @@ import styles from './document-comments.module.css'
 
 const AVATAR_URL =
     'https://bugs.earthdata.nasa.gov/secure/useravatar?size=large&ownerId=${uid}'
-const DEFAULT_PARENT_ID = 'root'
+export const DEFAULT_PARENT_ID = 'root'
 const DEFAULT_COMMENT = {
     text: '',
     resolved: false,
@@ -154,9 +154,14 @@ const CommentCard = ({
 
                 {showCardActions && (
                     <div className={styles.cardActions}>
-                        <IconButton alt="Reply to comment" onClick={handleReplyTo}>
-                            <MdReply />
-                        </IconButton>
+                        {comment.parentId == DEFAULT_PARENT_ID && (
+                            <IconButton
+                                alt="Reply to comment"
+                                onClick={handleReplyTo}
+                            >
+                                <MdReply />
+                            </IconButton>
+                        )}
 
                         {user.uid == comment.userUid && (
                             <IconButton

--- a/packages/app/components/document/document-comments.tsx
+++ b/packages/app/components/document/document-comments.tsx
@@ -11,7 +11,7 @@ import styles from './document-comments.module.css'
 
 const AVATAR_URL =
     'https://bugs.earthdata.nasa.gov/secure/useravatar?size=large&ownerId=${uid}'
-export const DEFAULT_PARENT_ID = 'root'
+const DEFAULT_PARENT_ID = 'root'
 const DEFAULT_COMMENT = {
     text: '',
     resolved: false,

--- a/packages/app/components/document/document-header.tsx
+++ b/packages/app/components/document/document-header.tsx
@@ -21,7 +21,8 @@ const DocumentHeader = ({
     comments = [],
     history = [],
 }) => {
-    const numberOfComments = comments === null ? 0 : comments.length
+    const numberOfComments =
+        comments === null ? 0 : comments.filter(c => !c.resolved).length
     const numberOfHistoryEntries = history === null ? 0 : history.length
 
     return (


### PR DESCRIPTION
Resolved comments were being incorrectly counted as active comments in the document header. Now the document header only counts unresolved comments.

Comments were infinitely nest-able. Now only top-level comments can be replied to. As a result of multiple levels of nesting, deeply-nested comments would remain unresolved when resolving the top-level comment. By allowing only one level of nesting, future comments will be correctly resolved without affecting current comments.