### PR TITLE
Only clear out publication statuses that don't match the document's current state

### DIFF
--- a/packages/legacy-api/controllers/Meditor.js
+++ b/packages/legacy-api/controllers/Meditor.js
@@ -55,6 +55,7 @@ async function handlePublicationAcknowledgements(message) {
                 [acknowledgement.statusCode == 200 ? 'publishedOn' : 'failedOn']:
                     Date.now(),
             }),
+            ...(acknowledgement.state && { state: acknowledgement.state }),
         }
 
         const db = client.db(DbName).collection(acknowledgement.model)
@@ -68,6 +69,9 @@ async function handlePublicationAcknowledgements(message) {
                 $pull: {
                     'x-meditor.publishedTo': {
                         target: acknowledgement.target,
+                        // if document is in "Published" state, this would clear out any publication statuses for **other** states
+                        // i.e. any publication statuses that are marked as "Draft" would be cleared out
+                        state: { $ne: acknowledgement.state },
                     },
                 },
             }


### PR DESCRIPTION
**Background**

A "Draft" document is published from mEditor. The "CMR Subscriber" picks it up and sends it on to CMR_UAT.

After sending it to CMR_UAT, the "CMR Subscriber" sends an acknowledgement back to mEditor.

Before mEditor stores this acknowledgement in the database, mEditor clears out any existing publication statuses, from the db, for the given subscriber (called "target" in the NATS messages, i.e. `cmr` for CMR subscriber)

**The problem**

If the subscriber pushes to **multiple** CMR providers, mEditor will only store **one** of the acknowledgements that comes back.

**The solution**

Don't clear out any publication statuses matching the same state as the document's state.

In other words, if a document is in "Published" state, clear out any publication statuses for **other** states (Draft, Under Review, etc.) but leave publication statuses in the "Published" state