### PR TITLE
fix: trim secrets read as files in legacy API

### DIFF
--- a/packages/legacy-api/controllers/Users.js
+++ b/packages/legacy-api/controllers/Users.js
@@ -30,7 +30,10 @@ function fromSecretOrEnv(key) {
     var SECRETS_DIR = '/run/secrets/'
 
     if (fs.existsSync(SECRETS_DIR + key)) {
-        return fs.readFileSync(SECRETS_DIR + key).toString()
+        return fs
+            .readFileSync(SECRETS_DIR + key)
+            .toString()
+            .trim()
     } else {
         return process.env[key] || process.env[key.toUpperCase()]
     }


### PR DESCRIPTION
I'm still not sure what in my system is adding newlines to the end of secrets read from files, but this PR trims the stringified secret after reading it, causing login to work. This PR unblocks GUUI-3277.