### PR TITLE
Feature/meditor 829 codepipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.9.13] - 28 Feb 2024
+## [Unreleased]
 
-### Fixed
+### Added
 
-- fixed NATS connection crashing meditor_ui (packages/app) on MCP environment
+- changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.9.13] - 28 Feb 2024
+
+### Fixed
+
+- fixed NATS connection crashing meditor_ui (packages/app) on MCP environment

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,68 @@
+## Used in AWS CodeBuild, called by AWS CodePipeline.
+# Docs: https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html
+# Requires the following environment variables set in CodeBuild:
+#   ACCOUNT: the account ID of the federated user (changes between SIT, UAT, and PROD)
+#   REGION: so far, us-east-1
+version: 0.2
+
+env:
+  shell: bash
+
+batch:
+  fast-fail: false
+  build-list:
+    - identifier: app
+      debug-session: false
+      env:
+        variables:
+          REPOSITORY_NAME: meditor/meditor_ui
+          PACKAGE_PATH: packages/app
+      ignore-failure: false
+    - identifier: docs
+      debug-session: false
+      env:
+        variables:
+          REPOSITORY_NAME: meditor/meditor_docs
+          PACKAGE_PATH: packages/docs
+      ignore-failure: false
+    - identifier: legacy_api
+      debug-session: false
+      env:
+        variables:
+          REPOSITORY_NAME: meditor/meditor_server
+          PACKAGE_PATH: packages/legacy-api
+      ignore-failure: false
+    - identifier: notebook_viewer
+      debug-session: false
+      env:
+        variables:
+          REPOSITORY_NAME: meditor/meditor_notebookviewer
+          PACKAGE_PATH: packages/notebook-viewer
+      ignore-failure: false
+    - identifier: notifier
+      debug-session: false
+      env:
+        variables:
+          REPOSITORY_NAME: meditor/meditor_notifier
+          PACKAGE_PATH: packages/notifier
+      ignore-failure: false
+    - identifier: proxy
+      debug-session: false
+      env:
+        variables:
+          REPOSITORY_NAME: meditor/meditor_proxy
+          PACKAGE_PATH: packages/proxy
+      ignore-failure: false
+
+phases:
+  pre_build:
+    commands:
+      - VERSION=$(./get_package_version.sh)
+      - aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $ACCOUNT.dkr.ecr.$REGION.amazonaws.com
+  build:
+    commands:
+      - docker build -t $REPOSITORY_NAME:${VERSION} $PACKAGE_PATH --build-arg REGISTRY=$ACCOUNT.dkr.ecr.$REGION.amazonaws.com/
+      - docker tag $REPOSITORY_NAME:${VERSION} $ACCOUNT.dkr.ecr.$REGION.amazonaws.com/$REPOSITORY_NAME:${VERSION}
+  post_build:
+    commands:
+      - docker push $ACCOUNT.dkr.ecr.$REGION.amazonaws.com/$REPOSITORY_NAME:${VERSION}

--- a/get_package_version.sh
+++ b/get_package_version.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Returns value of "version" field from package.json.
+# Assumes npm and correct scope of desired package.json (uses npm defaults).
+
+get_version() {
+	local version=$(npm pkg get version)
+
+	# Docker tag requires the value to not be surrounded in double-quotes.
+	# fails: "1.2.3"
+	# passes: 1.2.3
+	echo $version | awk -F'"' '{print $2}'
+}
+
+get_version

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "meditor",
-  "version": "1.9.12",
+  "version": "1.10.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meditor",
-  "version": "1.10.0",
+  "version": "1.9.12",
   "description": "mEditor, the model editor",
   "directories": {
     "example": "examples",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meditor",
-  "version": "1.9.12",
+  "version": "1.10.0",
   "description": "mEditor, the model editor",
   "directories": {
     "example": "examples",

--- a/packages/notebook-viewer/Dockerfile
+++ b/packages/notebook-viewer/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.9.1
+ARG REGISTRY
+FROM ${REGISTRY}python:3.9.1
 
 RUN mkdir -p /usr/src/app
 RUN apt-get update

--- a/packages/notifier/Dockerfile
+++ b/packages/notifier/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:10.12.0
+ARG REGISTRY
+FROM ${REGISTRY}node:10.12.0
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
This PR adds two features related to our AWS Deployment Pipeline:

1. adds a bash script to get the root `package.json`'s version for use in CodeBuild
2. adds ARG to the two Dockerfiles that didn't have it; we pull images from ECR when building with Docker to prevent a 429 response 