### PR TITLE
Allow creating documents under a different initial state

### DIFF
--- a/packages/app/components/jsonschemaform/widgets/MultiSelectWidget.tsx
+++ b/packages/app/components/jsonschemaform/widgets/MultiSelectWidget.tsx
@@ -14,6 +14,18 @@ function optionHasValue(option) {
     return option != ''
 }
 
+function getEnumOptionsAsLabelValue(
+    enumOptions: string[] | { label: string; value: string }[]
+) {
+    return (
+        enumOptions
+            ?.filter(optionHasValue)
+            .map(option =>
+                typeof option === 'string' ? { label: option, value: option } : option
+            ) ?? []
+    )
+}
+
 function MultiSelectWidget(props: WidgetProps) {
     const {
         id,
@@ -35,7 +47,7 @@ function MultiSelectWidget(props: WidgetProps) {
 
         let tagifyOptions = {
             mode: !props.multiple ? 'select' : null,
-            whitelist: options.enumOptions?.filter(optionHasValue) ?? [],
+            whitelist: getEnumOptionsAsLabelValue(options.enumOptions),
             enforceWhitelist:
                 'enforceEnumOptions' in options ? options.enforceEnumOptions : true,
             keepInvalidTags:
@@ -66,7 +78,7 @@ function MultiSelectWidget(props: WidgetProps) {
     useEffect(() => {
         if (!tagify) return
 
-        tagify.settings.whitelist = options.enumOptions?.filter(optionHasValue) ?? []
+        tagify.settings.whitelist = getEnumOptionsAsLabelValue(options.enumOptions)
     }, [tagify, options.enum, options.enumOptions])
 
     let filteredValue = value && typeof value === 'string' ? [value] : value

--- a/packages/app/documents/__tests__/__fixtures__/workflow-with-two-initial-nodes.json
+++ b/packages/app/documents/__tests__/__fixtures__/workflow-with-two-initial-nodes.json
@@ -1,0 +1,122 @@
+{
+    "roles": ["Author", "Post-Publish Reviewer"],
+    "nodes": [
+        {
+            "privileges": [
+                {
+                    "privilege": ["create"],
+                    "role": "Author"
+                }
+            ],
+            "id": "Init",
+            "readyForUse": false
+        },
+        {
+            "privileges": [
+                {
+                    "privilege": ["edit", "comment"],
+                    "role": "Author"
+                }
+            ],
+            "id": "Draft",
+            "readyForUse": false
+        },
+        {
+            "id": "Another Init Node",
+            "allowValidationErrors": true
+        },
+        {
+            "privileges": [
+                {
+                    "privilege": ["comment", "edit"],
+                    "role": "Author"
+                }
+            ],
+            "id": "Published",
+            "readyForUse": false
+        },
+        {
+            "privileges": [
+                {
+                    "privilege": ["comment"],
+                    "role": "Post-Publish Reviewer"
+                },
+                {
+                    "privilege": ["edit", "comment"],
+                    "role": "Author"
+                }
+            ],
+            "id": "Hidden",
+            "readyForUse": false
+        },
+        {
+            "id": "Deleted",
+            "privileges": [
+                {
+                    "role": "Author",
+                    "privilege": ["edit", "comment"]
+                }
+            ]
+        }
+    ],
+    "edges": [
+        {
+            "label": "Add New",
+            "notify": false,
+            "role": "Author",
+            "source": "Init",
+            "target": "Draft"
+        },
+        {
+            "label": "Publish",
+            "notify": true,
+            "role": "Author",
+            "source": "Draft",
+            "target": "Published",
+            "notifyRoles": "Post-Publish Reviewer"
+        },
+        {
+            "label": "Delete Permanently",
+            "notify": false,
+            "role": "Author",
+            "source": "Draft",
+            "target": "Deleted"
+        },
+        {
+            "label": "Delete Permanently",
+            "notify": false,
+            "role": "Author",
+            "source": "Hidden",
+            "target": "Deleted"
+        },
+        {
+            "label": "Delete Permanently",
+            "notify": false,
+            "role": "Author",
+            "source": "Published",
+            "target": "Deleted",
+            "notifyRoles": "Post-Publish Reviewer"
+        },
+        {
+            "label": "Un-publish",
+            "notify": false,
+            "role": "Post-Publish Reviewer",
+            "source": "Published",
+            "target": "Hidden"
+        },
+        {
+            "role": "Author",
+            "source": "Init",
+            "target": "Another Init Node",
+            "label": "Create Another Init Node",
+            "notify": false
+        },
+        {
+            "role": "Author",
+            "source": "Another Init Node",
+            "target": "Draft",
+            "label": "Save as Draft"
+        }
+    ],
+    "name": "Two-Init-Nodes"
+}

--- a/packages/app/pages/api/models/[modelName]/documents/index.ts
+++ b/packages/app/pages/api/models/[modelName]/documents/index.ts
@@ -54,7 +54,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             const [documentError, data] = await createDocument(
                 parsedDocument,
                 modelName,
-                user
+                user,
+                req.query.initialState?.toString()
             )
 
             if (documentError) {


### PR DESCRIPTION
**Use case** 

To support our work with EDPub, we'd like "Collection Metadata" documents sent from EDPub to be temporarily quarantined in a state other than "Draft"; until a curator has a chance to review it.

This is accomplished by adding a new node to the workflow and a new query parameter to the createDocument endpoint: 'initialState'

The provided initialState must satisfy these conditions:
1. has to be a state in the model's workflow
2. has to be an INITIAL state (i.e. has an edge that connects to the "Init" node)

**To Test**

* Backup your current "Edit-Publish-CMR" workflow JSON just in case
* Replace your "Edit-Publish-CMR" workflow JSON with this file [Edit-Publish-CMR.json](https://github.com/nasa/gesdisc-meditor/files/14515635/Edit-Publish-CMR.json)
 (visit http://localhost/meditor/Workflows/Edit-Publish-CMR then click on Document JSON and paste in the attached JSON)

(This part you may need help with, was a chore to figure out authentication via Postman)

* Send a POST request to the `/meditor/api/models/Collection Metadata/documents?initialState=From EarthdataPub` endpoint, note the initialState.
* Visit the "Collection Metadata" document list page and you should see the document you created