### PR TITLE
32 implement bulk operations endpoints

### DIFF
--- a/packages/app/components/jsonschemaform/widgets/MultiSelectWidget.tsx
+++ b/packages/app/components/jsonschemaform/widgets/MultiSelectWidget.tsx
@@ -19,6 +19,7 @@ function getEnumOptionsAsLabelValue(
 ) {
     return (
         enumOptions
+            // @ts-ignore
             ?.filter(optionHasValue)
             .map(option =>
                 typeof option === 'string' ? { label: option, value: option } : option

--- a/packages/app/documents/schema.ts
+++ b/packages/app/documents/schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-const getDocumentInputSchema = z.object({
+export const getDocumentInputSchema = z.object({
     documentTitle: z.string().min(1),
     documentVersion: z.string().endsWith('Z').optional(),
     modelName: z.string().min(1),
@@ -9,4 +9,22 @@ const getDocumentInputSchema = z.object({
     uid: z.string().min(1).optional(),
 })
 
-export { getDocumentInputSchema }
+export const patchDocumentsHeadersSchema = z.object({
+    'if-match': z
+        .string()
+        .regex(
+            new RegExp(/^"([^"]+)"(,\s*"[^"]+")*$/),
+            'must be a comma-separated list of document titles to update (ex. "title1", "title2", ...)'
+        ),
+})
+
+export const patchDocumentsInputSchema = z.array(
+    z.object({
+        // must match an operation found in https://jsonpatch.com/
+        op: z.enum(['add', 'remove', 'replace', 'move', 'copy', 'test']),
+        // path must match the format `/PATH/SUBPATH` (starts with a / follow by one or more characters)
+        path: z.string().min(2).regex(new RegExp(/^\/.+/)),
+        // value is optional
+        value: z.any().optional(),
+    })
+)

--- a/packages/app/documents/schema.ts
+++ b/packages/app/documents/schema.ts
@@ -9,7 +9,7 @@ export const getDocumentInputSchema = z.object({
     uid: z.string().min(1).optional(),
 })
 
-export const patchDocumentsHeadersSchema = z.object({
+export const bulkDocumentHeadersSchema = z.object({
     'if-match': z
         .string()
         .regex(

--- a/packages/app/documents/types.ts
+++ b/packages/app/documents/types.ts
@@ -65,3 +65,9 @@ export interface DocumentMessage {
 export interface DocumentMessageModel {
     titleProperty: string
 }
+
+export type BulkDocumentResponse = {
+    title: string
+    status: number
+    error?: string
+}

--- a/packages/app/package-lock.json
+++ b/packages/app/package-lock.json
@@ -27,6 +27,7 @@
                 "fuse.js": "^6.6.2",
                 "he": "^1.2.0",
                 "immer": "^9.0.6",
+                "immutable-json-patch": "^6.0.1",
                 "isomorphic-unfetch": "^3.0.0",
                 "jest": "^28.1.1",
                 "json-mapper-json": "^1.3.3",
@@ -6228,6 +6229,11 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/immer"
             }
+        },
+        "node_modules/immutable-json-patch": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/immutable-json-patch/-/immutable-json-patch-6.0.1.tgz",
+            "integrity": "sha512-BHL/cXMjwFZlTOffiWNdY8ZTvNyYLrutCnWxrcKPHr5FqpAb6vsO6WWSPnVSys3+DruFN6lhHJJPHi8uELQL5g=="
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
@@ -15241,6 +15247,11 @@
             "version": "9.0.16",
             "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.16.tgz",
             "integrity": "sha512-qenGE7CstVm1NrHQbMh8YaSzTZTFNP3zPqr3YU0S0UY441j4bJTg4A2Hh5KAhwgaiU6ZZ1Ar6y/2f4TblnMReQ=="
+        },
+        "immutable-json-patch": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/immutable-json-patch/-/immutable-json-patch-6.0.1.tgz",
+            "integrity": "sha512-BHL/cXMjwFZlTOffiWNdY8ZTvNyYLrutCnWxrcKPHr5FqpAb6vsO6WWSPnVSys3+DruFN6lhHJJPHi8uELQL5g=="
         },
         "import-fresh": {
             "version": "3.3.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -32,6 +32,7 @@
         "fuse.js": "^6.6.2",
         "he": "^1.2.0",
         "immer": "^9.0.6",
+        "immutable-json-patch": "^6.0.1",
         "isomorphic-unfetch": "^3.0.0",
         "jest": "^28.1.1",
         "json-mapper-json": "^1.3.3",

--- a/packages/app/pages/api/models/[modelName]/documents/bulk/change-document-state.ts
+++ b/packages/app/pages/api/models/[modelName]/documents/bulk/change-document-state.ts
@@ -1,0 +1,64 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getLoggedInUser } from 'auth/user'
+import { bulkChangeDocumentState } from 'documents/service'
+import { respondAsJson } from 'utils/api'
+import {
+    apiError,
+    ErrorCode,
+    formatZodError,
+    HttpException,
+    parseZodAsErrorData,
+} from 'utils/errors'
+import { bulkDocumentHeadersSchema } from 'documents/schema'
+import type { ZodError } from 'zod'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    const modelName = decodeURIComponent(req.query.modelName.toString())
+    const newState = decodeURIComponent(req.query.state?.toString())
+
+    const user = await getLoggedInUser(req, res)
+
+    if (req.method !== 'POST') {
+        return apiError(
+            new HttpException(ErrorCode.MethodNotAllowed, 'Method not allowed'),
+            res
+        )
+    }
+
+    //* we enforce requiring the user to provide explicit identifiers for the documents to patch (we don't support all)
+    //* the standard is to use an "If-Match" header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match
+    const [headersError, headers] = parseZodAsErrorData<any>(
+        bulkDocumentHeadersSchema,
+        req.headers
+    )
+
+    if (headersError) {
+        return apiError(
+            formatZodError(headersError as ZodError, '`If-Match` header: '), // format the ZodError so we can use a custom error message prefix
+            res
+        )
+    }
+
+    //* parse the document titles from 'If-Match'
+    const documentTitles = headers['if-match']
+        .split(',')
+        .map(title => title.trim().replace(/^"/, '').replace(/"$/, ''))
+
+    //* perform state updates for all documents
+    const [error, result] = await bulkChangeDocumentState(
+        documentTitles,
+        modelName,
+        newState,
+        user,
+        {
+            // disable email notifications by default, this is a bulk endpoint which will spam the userbase
+            disableEmailNotifications: req.query.notify?.toString() !== 'true',
+        }
+    )
+
+    if (error) {
+        return apiError(error, res)
+    }
+
+    return respondAsJson(result, req, res)
+}

--- a/packages/app/pages/api/models/[modelName]/documents/bulk/index.ts
+++ b/packages/app/pages/api/models/[modelName]/documents/bulk/index.ts
@@ -1,0 +1,89 @@
+import { getLoggedInUser } from 'auth/user'
+import {
+    bulkDocumentHeadersSchema,
+    patchDocumentsInputSchema,
+} from 'documents/schema'
+import { bulkPatchDocuments } from 'documents/service'
+import type { JSONPatchDocument } from 'immutable-json-patch'
+import { userCanAccessModel } from 'models/service'
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { respondAsJson } from 'utils/api'
+import {
+    apiError,
+    ErrorCode,
+    formatZodError,
+    HttpException,
+    parseZodAsErrorData,
+} from 'utils/errors'
+import type { ZodError } from 'zod'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    const modelName = decodeURIComponent(req.query.modelName.toString())
+    const user = await getLoggedInUser(req, res)
+
+    if (!userCanAccessModel(modelName, user)) {
+        return apiError(
+            new HttpException(
+                ErrorCode.ForbiddenError,
+                'User does not have access to the requested model'
+            ),
+            res
+        )
+    }
+
+    switch (req.method) {
+        case 'PATCH': {
+            if (!user) {
+                return apiError(
+                    new HttpException(ErrorCode.Unauthorized, 'Unauthorized'),
+                    res
+                )
+            }
+
+            //* we enforce requiring the user to provide explicit identifiers for the documents to patch (we don't support all/*)
+            //* the standard is to use an "If-Match" header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match
+            const [headersError, headers] = parseZodAsErrorData<any>(
+                bulkDocumentHeadersSchema,
+                req.headers
+            )
+
+            if (headersError) {
+                return apiError(
+                    formatZodError(headersError as ZodError, '`If-Match` header: '), // format the ZodError so we can use a custom error message prefix
+                    res
+                )
+            }
+
+            //* parse the document titles from 'If-Match'
+            const documentTitles = headers['if-match']
+                .split(',')
+                .map(title => title.trim().replace(/^"/, '').replace(/"$/, ''))
+
+            //* we'll also parse the list of operations the user requested, this will ensure they match the right format for the JSON patch spec
+            const [parsingError, operations] = parseZodAsErrorData<JSONPatchDocument>(
+                patchDocumentsInputSchema,
+                req.body
+            )
+
+            if (parsingError) {
+                return apiError(parsingError, res)
+            }
+
+            const [error, result] = await bulkPatchDocuments(
+                documentTitles,
+                modelName,
+                user,
+                operations
+            )
+
+            if (error) {
+                return apiError(error, res)
+            }
+
+            return respondAsJson(result, req, res)
+        }
+
+        default:
+            return res.status(405).end()
+    }
+}

--- a/packages/app/pages/api/models/[modelName]/documents/index.ts
+++ b/packages/app/pages/api/models/[modelName]/documents/index.ts
@@ -1,10 +1,26 @@
 import { getLoggedInUser } from 'auth/user'
-import { createDocument, getDocumentsForModel } from 'documents/service'
+import {
+    patchDocumentsHeadersSchema,
+    patchDocumentsInputSchema,
+} from 'documents/schema'
+import {
+    createDocument,
+    getDocumentsForModel,
+    patchDocuments,
+} from 'documents/service'
+import type { JSONPatchDocument } from 'immutable-json-patch'
 import { userCanAccessModel } from 'models/service'
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { respondAsJson } from 'utils/api'
-import { apiError, ErrorCode, HttpException } from 'utils/errors'
+import {
+    apiError,
+    ErrorCode,
+    formatZodError,
+    HttpException,
+    parseZodAsErrorData,
+} from 'utils/errors'
 import { safeParseJSON } from 'utils/json'
+import type { ZodError } from 'zod'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     const modelName = decodeURIComponent(req.query.modelName.toString())
@@ -69,6 +85,57 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             return respondAsJson(apiSafeDocument, req, res, {
                 httpStatusCode: 201,
             })
+        }
+
+        case 'PATCH': {
+            if (!user) {
+                return apiError(
+                    new HttpException(ErrorCode.Unauthorized, 'Unauthorized'),
+                    res
+                )
+            }
+
+            //* we enforce requiring the user to provide explicit identifiers for the documents to patch (we don't support all/*)
+            //* the standard is to use an "If-Match" header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match
+            const [headersError, headers] = parseZodAsErrorData<any>(
+                patchDocumentsHeadersSchema,
+                req.headers
+            )
+
+            if (headersError) {
+                return apiError(
+                    formatZodError(headersError as ZodError, '`If-Match` header: '), // format the ZodError so we can use a custom error message prefix
+                    res
+                )
+            }
+
+            //* parse the document titles from 'If-Match'
+            const documentTitles = headers['if-match']
+                .split(',')
+                .map(title => title.trim().replace(/^"/, '').replace(/"$/, ''))
+
+            //* we'll also parse the list of operations the user requested, this will ensure they match the right format for the JSON patch spec
+            const [parsingError, operations] = parseZodAsErrorData<JSONPatchDocument>(
+                patchDocumentsInputSchema,
+                req.body
+            )
+
+            if (parsingError) {
+                return apiError(parsingError, res)
+            }
+
+            const [error, result] = await patchDocuments(
+                documentTitles,
+                modelName,
+                user,
+                operations
+            )
+
+            if (error) {
+                return apiError(error, res)
+            }
+
+            return respondAsJson(result, req, res)
         }
 
         default:

--- a/packages/app/pages/api/models/[modelName]/documents/index.ts
+++ b/packages/app/pages/api/models/[modelName]/documents/index.ts
@@ -1,26 +1,10 @@
 import { getLoggedInUser } from 'auth/user'
-import {
-    patchDocumentsHeadersSchema,
-    patchDocumentsInputSchema,
-} from 'documents/schema'
-import {
-    createDocument,
-    getDocumentsForModel,
-    patchDocuments,
-} from 'documents/service'
-import type { JSONPatchDocument } from 'immutable-json-patch'
+import { createDocument, getDocumentsForModel } from 'documents/service'
 import { userCanAccessModel } from 'models/service'
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { respondAsJson } from 'utils/api'
-import {
-    apiError,
-    ErrorCode,
-    formatZodError,
-    HttpException,
-    parseZodAsErrorData,
-} from 'utils/errors'
+import { apiError, ErrorCode, HttpException } from 'utils/errors'
 import { safeParseJSON } from 'utils/json'
-import type { ZodError } from 'zod'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     const modelName = decodeURIComponent(req.query.modelName.toString())
@@ -85,57 +69,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             return respondAsJson(apiSafeDocument, req, res, {
                 httpStatusCode: 201,
             })
-        }
-
-        case 'PATCH': {
-            if (!user) {
-                return apiError(
-                    new HttpException(ErrorCode.Unauthorized, 'Unauthorized'),
-                    res
-                )
-            }
-
-            //* we enforce requiring the user to provide explicit identifiers for the documents to patch (we don't support all/*)
-            //* the standard is to use an "If-Match" header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match
-            const [headersError, headers] = parseZodAsErrorData<any>(
-                patchDocumentsHeadersSchema,
-                req.headers
-            )
-
-            if (headersError) {
-                return apiError(
-                    formatZodError(headersError as ZodError, '`If-Match` header: '), // format the ZodError so we can use a custom error message prefix
-                    res
-                )
-            }
-
-            //* parse the document titles from 'If-Match'
-            const documentTitles = headers['if-match']
-                .split(',')
-                .map(title => title.trim().replace(/^"/, '').replace(/"$/, ''))
-
-            //* we'll also parse the list of operations the user requested, this will ensure they match the right format for the JSON patch spec
-            const [parsingError, operations] = parseZodAsErrorData<JSONPatchDocument>(
-                patchDocumentsInputSchema,
-                req.body
-            )
-
-            if (parsingError) {
-                return apiError(parsingError, res)
-            }
-
-            const [error, result] = await patchDocuments(
-                documentTitles,
-                modelName,
-                user,
-                operations
-            )
-
-            if (error) {
-                return apiError(error, res)
-            }
-
-            return respondAsJson(result, req, res)
         }
 
         default:

--- a/packages/app/utils/errors.ts
+++ b/packages/app/utils/errors.ts
@@ -120,14 +120,17 @@ export function parseZodAsErrorData<T>(schema: ZodSchema, input: any): ErrorData
     }
 }
 
-function formatZodError(error: ZodError) {
+export function formatZodError(error: ZodError, messagePrefix?: string) {
     const errorString = error.issues.reduce((accumulator, current, index, self) => {
         //* We want spaces between errors but not for the last error.
         const maybeSpace = index + 1 === self.length ? '' : ' '
 
-        accumulator += `For query ${parameterWithInflection(
-            current.path.length
-        )} ${current.path.toString()}: ${current.message}.${maybeSpace}`
+        accumulator += `${
+            messagePrefix ??
+            `For query ${parameterWithInflection(
+                current.path.length
+            )} ${current.path.toString()}: `
+        }${current.message}.${maybeSpace}`
 
         return accumulator
     }, ``)

--- a/packages/docs/api-spec/v1.yaml
+++ b/packages/docs/api-spec/v1.yaml
@@ -122,6 +122,87 @@ paths:
                     description: Not Found
                 '500':
                     description: Internal Server Error
+    /models/{modelName}/documents/bulk:
+        patch:
+            tags:
+                - documents
+            summary: make bulk updates to one or more documents
+            description: Make bulk updates to one or more documents
+            operationId: bulkPatchDocument
+            parameters:
+                - name: modelName
+                  in: path
+                  description: name of model
+                  required: true
+                  schema:
+                      type: string
+                - name: If-Match
+                  in: header
+                  description: A comma-delimited list of document titles to update
+                  example: '"News Article", "Another News Article"'
+                  required: true
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            type: array
+                            items:
+                                oneOf:
+                                    - $ref: '#/components/schemas/AddPatchOperation'
+                                    - $ref: '#/components/schemas/RemovePatchOperation'
+                                    - $ref: '#/components/schemas/ReplacePatchOperation'
+                                    - $ref: '#/components/schemas/CopyPatchOperation'
+                                    - $ref: '#/components/schemas/MovePatchOperation'
+                                    - $ref: '#/components/schemas/TestPatchOperation'
+                description: a list of patch operations to perform (see https://jsonpatch.com/ for more details)
+                required: true
+            responses:
+                '200':
+                    description: OK
+                '400':
+                    description: Bad Request
+                '401':
+                    description: Unauthorized
+                '404':
+                    description: Not Found
+                '500':
+                    description: Internal Server Error
+    /models/{modelName}/documents/bulk/change-document-state:
+        post:
+            tags:
+                - documents
+            summary: change many document's state
+            description: Change many document's state.
+            operationId: bulkChangeDocumentState
+            parameters:
+                - name: modelName
+                  in: path
+                  description: name of model
+                  required: true
+                  schema:
+                      type: string
+                - name: newState
+                  in: query
+                  description: the document's desired state
+                  required: true
+                  schema:
+                      type: string
+                - name: If-Match
+                  in: header
+                  description: A comma-delimited list of document titles to update
+                  example: '"News Article", "Another News Article"'
+                  required: true
+            responses:
+                '200':
+                    description: OK
+                '400':
+                    description: Bad Request
+                '401':
+                    description: Unauthorized
+                '404':
+                    description: Not Found
+                '500':
+                    description: Internal Server Error
     /models/{modelName}/documents/{documentTitle}:
         get:
             tags:
@@ -580,3 +661,61 @@ paths:
                     description: Bad Request
                 '500':
                     description: Internal Server Error
+components:
+    schemas:
+        PatchOperation:
+            type: object
+            required:
+                - op
+                - path
+            properties:
+                op:
+                    type: string
+                    enum: [add, remove, replace, copy, move, test]
+                    example: add
+                path:
+                    type: string
+                    example: /Path/To/Field
+
+        PatchWithValueOperation:
+            allOf: # Combines the PatchOperation and the inline model
+                - $ref: '#/components/schemas/PatchOperation'
+                - type: object
+            required:
+                - value
+            properties:
+                value:
+                    oneOf:
+                        - type: string
+                        - type: array
+                          items:
+                              type: integer
+
+        PatchWithFromOperation:
+            allOf: # Combines the PatchOperation and the inline model
+                - $ref: '#/components/schemas/PatchOperation'
+                - type: object
+            required:
+                - from
+            properties:
+                from:
+                    type: string
+                    example: /Path/To/Field
+
+        AddPatchOperation:
+            $ref: '#/components/schemas/PatchWithValueOperation'
+
+        RemovePatchOperation:
+            $ref: '#/components/schemas/PatchOperation'
+
+        ReplacePatchOperation:
+            $ref: '#/components/schemas/PatchWithValueOperation'
+
+        CopyPatchOperation:
+            $ref: '#/components/schemas/PatchWithFromOperation'
+
+        MovePatchOperation:
+            $ref: '#/components/schemas/PatchWithFromOperation'
+
+        TestPatchOperation:
+            $ref: '#/components/schemas/PatchWithValueOperation'

--- a/packages/docs/docs/user-guide/bulk-updates.mdx
+++ b/packages/docs/docs/user-guide/bulk-updates.mdx
@@ -1,0 +1,111 @@
+---
+title: Bulk Updates
+---
+
+## JSON Patch
+
+The [Bulk Documents] endpoint uses the [JSON Patch specification](https://jsonpatch.com/).
+
+This specification describes a set of instruction on how to modify a resource.
+
+### Identifying documents to update
+
+The bulk documents endpoint requires the inclusion of an `If-Match` headers, which is a comma-delimited list of the document titles to update.
+
+For example, to edit three documents, titled "A", "B", and "C", you would include the following header with your request:
+
+`If-Match: "A", "B", "C"`
+
+### Operations Syntax
+
+mEditor supports all of the supported JSON Patch operations found in the specification linked above.
+
+Additionally, you can include as many operations as you want in one request.
+
+Each operation object in the request body consists of 3 main attributes:
+[0] op — indicates the operation to perform. As per the specification, its value MUST be one of “add”, “remove”, “replace”, “move”, “copy”, or “test”
+[1] path — string containing a JSON-Pointer value that references the “target location” where the operation is performed
+[2] value — data to be operated for the given path
+
+#### "add"
+
+Adds a value to an object or inserts it into an array. In the case of an array, the value is inserted before the given index. The - character can be used instead of an index to insert at the end of an array.
+
+Example, add a "Science Keyword" to many collections at once:
+
+```
+If-Match: "GPM_3IMERGHH_06", "GPM_3IMERGHH_07"
+
+[
+    { "op": "add", "path": "/Science_Keywords/-", "value": "EARTH SCIENCE > ATMOSPHERE > PRECIPITATION" }
+]
+```
+
+#### "remove"
+
+Removes a value from an object or array.
+
+Example: Remove the `Dataset_Progress` field from a list of collections
+
+```
+If-Match: "GPM_3IMERGHH_06", "GPM_3IMERGHH_07"
+
+[
+    { "op": "remove", "path": "/Dataset_Progress" }
+]
+```
+
+#### "replace"
+
+Replaces a value. Equivalent to a “remove” followed by an “add”.
+
+Example: Replace the `Dataset_Progress` field in a list of collections
+
+```
+If-Match: "GPM_3IMERGHH_06", "GPM_3IMERGHH_07"
+
+[
+    { "op": "replace", "path": "/Dataset_Progress", "value": "COMPLETE" }
+]
+```
+
+#### "copy"
+
+Copies a value from one location to another within the JSON document. Both from and path are JSON Pointers.
+
+Example, renaming a field, copy the old field to the new field:
+
+```
+If-Match: "GPM_3IMERGHH_06", "GPM_3IMERGHH_07"
+
+[
+    { "op": "copy", "from": "/Dataset_Version", "path": "/Version" }
+]
+```
+
+#### "move"
+
+Moves a value from one location to the other. Both from and path are JSON Pointers.
+
+Example, same as above. Rename a field, though this time the old field is removed.
+
+```
+If-Match: "GPM_3IMERGHH_06", "GPM_3IMERGHH_07"
+
+[
+    { "op": "move", "from": "/Dataset_Version", "path": "/Version" }
+]
+```
+
+#### "test"
+
+Tests that the specified value is set in the document. If the test fails, then the patch as a whole should not apply.
+
+```
+If-Match: "GPM_3IMERGHH_06", "GPM_3IMERGHH_07"
+
+[
+    { "op": "test", "path": "/AwsEnabled", "value": true },
+    { "op": "replace", "path": "/Region", "value": "us-east-1" }
+]
+```

--- a/packages/docs/sidebars.js
+++ b/packages/docs/sidebars.js
@@ -23,6 +23,7 @@ const sidebars = {
                 'user-guide/using-comments',
                 'user-guide/versions-and-history',
                 'user-guide/search-syntax',
+                'user-guide/bulk-updates',
             ],
         },
     ],


### PR DESCRIPTION
Adding two new endpoints:
* /api/models/{modelName}/documents/bulk
* /api/models/{modelName}/documents/bulk/change-document-state

Both endpoints take an `If-Match` header to determine which documents to affect. Looks like this: `"Title 1", "Title 2"

The first endpoint accepts one or more patch operations found in jsonpatch.com

The second endpoint has the same requirements as the existing 'change-document-state' endpoint, but includes an `If-Match` header to allow for things like, publishing many documents at once.

Finally, have updated the documentation, adding a user guide page and new endpoints to the API docs