### PR TITLE
feat(app): add strict schema validation endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.0] - 2024-06-04
+
+### Added
+
+- `/api/models/[modelName]/validate` endpoint for strict validation of documents against their model's schema
+
 ## [1.9.13] - 2024 05-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meditor",
-  "version": "1.9.13",
+  "version": "1.10.0",
   "description": "mEditor, the model editor",
   "directories": {
     "example": "examples",

--- a/packages/app/documents/__tests__/__fixtures__/alertOnlyDocument.json
+++ b/packages/app/documents/__tests__/__fixtures__/alertOnlyDocument.json
@@ -1,0 +1,7 @@
+{
+    "severity": "normal",
+    "title": "Forward stream data temporarily unavailable from AWS cloud",
+    "start": "2023-12-26 12:00:00-05:00",
+    "expiration": "2024-01-01 12:00:00-05:00",
+    "body": "<p>As of 9:00 AM Tuesday, December 26, 2023, granule ingest into AWS cloud was paused due to an ongoing operations issue. Users who use search interfaces, including Giovanni, will have issues discovering cloud-enabled data that have been archived in the past couple of days. This is not impacting users who directly access and download data from on-premises archive hosts at the GES DISC. We plan to resolve this issue and resume granule ingest by Sunday, December 31, 2023, though this is subject to change.</p>\n"
+}

--- a/packages/app/documents/__tests__/__fixtures__/alerts-before-modified-state.json
+++ b/packages/app/documents/__tests__/__fixtures__/alerts-before-modified-state.json
@@ -45,6 +45,7 @@
         },
         "title": "TRMM GrADS DODS Server",
         "body": "<p>The TRMM GDS services are temporarily suspended until the respective GrADS-DODS server is updated, and we can ensure it is properly maintained. The TRMM GDS has been exposing incomplete data series, as well as data we can no longer provide support for. The tentative timeline to resume this service is February, 2017.</p><p>Meanwhile, Users are encouraged to explore the OPeNDAP hyrax server:</p><p>http://disc2.gesdisc.eosdis.nasa.gov/opendap/TRMM_RT/contents.html </p><div></div>\n",
+        "severity": "normal",
         "expiration": "2016-11-01T04:00:00Z",
         "start": "2016-10-14T04:00:00Z",
         "tags": [],

--- a/packages/app/documents/service.ts
+++ b/packages/app/documents/service.ts
@@ -735,17 +735,16 @@ export async function strictValidateDocument(
 ): Promise<ErrorData<Document>> {
     try {
         //* Get the model for its schema and title property.
-        const [modelWithWorkflowError, modelWithWorkflow] =
-            await getModelWithWorkflow(modelName, undefined, {
-                populateMacroTemplates: true,
-            })
+        const [modelError, model] = await getModel(modelName, {
+            includeId: false,
+            populateMacroTemplates: true,
+        })
 
-        if (modelWithWorkflowError) {
-            throw modelWithWorkflowError
+        if (modelError) {
+            throw modelError
         }
 
-        const { schema, titleProperty } = modelWithWorkflow
-
+        const { schema, titleProperty } = model
         const { errors } = validate(documentToValidate, {
             ...JSON.parse(schema),
             additionalProperties: false,

--- a/packages/app/documents/service.ts
+++ b/packages/app/documents/service.ts
@@ -725,3 +725,50 @@ function getWorkflowEdgesMatchingSourceAndTarget(
         edge => edge.source === source && edge.target === target
     )
 }
+
+/**
+ * Validates a document against its schema strictly, allowing no additiona properties.
+ */
+export async function strictValidateDocument(
+    documentToValidate: any,
+    modelName: string
+): Promise<ErrorData<Document>> {
+    try {
+        //* Get the model for its schema and title property.
+        const [modelWithWorkflowError, modelWithWorkflow] =
+            await getModelWithWorkflow(modelName, undefined, {
+                populateMacroTemplates: true,
+            })
+
+        if (modelWithWorkflowError) {
+            throw modelWithWorkflowError
+        }
+
+        const { schema, titleProperty } = modelWithWorkflow
+
+        const { errors } = validate(documentToValidate, {
+            ...JSON.parse(schema),
+            additionalProperties: false,
+        })
+
+        //* Unlike most use-cases, we don't want to throw for a validation error; we just return it.
+        if (errors.length) {
+            const validationError = new HttpException(
+                ErrorCode.ValidationError,
+                `Document "${
+                    documentToValidate[titleProperty]
+                }" does not validate against the schema for model "${modelName}": ${JSON.stringify(
+                    errors.map(formatValidationErrorMessage)
+                )}`
+            )
+
+            return [validationError, null]
+        }
+
+        return [null, documentToValidate]
+    } catch (error) {
+        log.error(error)
+
+        return [error, null]
+    }
+}

--- a/packages/app/package-lock.json
+++ b/packages/app/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "meditor",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "meditor",
-            "version": "0.1.0",
+            "version": "1.0.0",
             "dependencies": {
                 "@gesdisc/meditor-components": "^1.0.9",
                 "@json2csv/node": "^7.0.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "meditor",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/packages/app/pages/api/models/[modelName]/validate/index.ts
+++ b/packages/app/pages/api/models/[modelName]/validate/index.ts
@@ -21,20 +21,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     switch (req.method) {
-        //* GET returns the model's schema that will be used to valide the document.
-        case 'GET': {
-            const [modelWithWorkflowError, modelWithWorkflow] =
-                await getModelWithWorkflow(modelName, undefined, {
-                    populateMacroTemplates: true,
-                })
-
-            if (modelWithWorkflowError) {
-                return apiError(modelWithWorkflowError, res)
-            }
-
-            return respondAsJson(JSON.parse(modelWithWorkflow.schema), req, res)
-        }
-
         //* Unlike most POST endpoints, this allows unauthenticated access.
         case 'POST': {
             const [parsingError, parsedDocument] = safeParseJSON(req.body)

--- a/packages/app/pages/api/models/[modelName]/validate/index.ts
+++ b/packages/app/pages/api/models/[modelName]/validate/index.ts
@@ -1,0 +1,63 @@
+import { getLoggedInUser } from 'auth/user'
+import { strictValidateDocument } from 'documents/service'
+import { getModelWithWorkflow, userCanAccessModel } from 'models/service'
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { respondAsJson } from 'utils/api'
+import { apiError, ErrorCode, HttpException } from 'utils/errors'
+import { safeParseJSON } from 'utils/json'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    const modelName = decodeURIComponent(req.query.modelName.toString())
+    const user = await getLoggedInUser(req, res)
+
+    if (!userCanAccessModel(modelName, user)) {
+        return apiError(
+            new HttpException(
+                ErrorCode.ForbiddenError,
+                'User does not have access to the requested model'
+            ),
+            res
+        )
+    }
+
+    switch (req.method) {
+        //* GET returns the model's schema that will be used to valide the document.
+        case 'GET': {
+            const [modelWithWorkflowError, modelWithWorkflow] =
+                await getModelWithWorkflow(modelName, undefined, {
+                    populateMacroTemplates: true,
+                })
+
+            if (modelWithWorkflowError) {
+                return apiError(modelWithWorkflowError, res)
+            }
+
+            return respondAsJson(JSON.parse(modelWithWorkflow.schema), req, res)
+        }
+
+        //* Unlike most POST endpoints, this allows unauthenticated access.
+        case 'POST': {
+            const [parsingError, parsedDocument] = safeParseJSON(req.body)
+
+            if (parsingError) {
+                return apiError(parsingError, res)
+            }
+
+            const [validationError, validDocument] = await strictValidateDocument(
+                parsedDocument,
+                modelName
+            )
+
+            if (validationError) {
+                return apiError(validationError, res)
+            }
+
+            return respondAsJson(validDocument, req, res, {
+                httpStatusCode: 200,
+            })
+        }
+
+        default:
+            return res.status(405).end()
+    }
+}

--- a/packages/app/search/__tests__/search.test.ts
+++ b/packages/app/search/__tests__/search.test.ts
@@ -322,8 +322,6 @@ describe('search', () => {
             pageNumber
         )
 
-        console.log(searchError)
-
         expect(searchError).toBe(null)
         expect(searchResults.results.length).toBe(0)
         expect(searchResults.results).toStrictEqual([])

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -38,3 +38,11 @@ npm run build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
+
+### Generate API Docs
+
+```bash
+npm run gen-api-docs meditor
+```
+
+This command generates static content into the `build` directory for the API documentation and can be served using any static contents hosting service.

--- a/packages/docs/api-spec/v1.yaml
+++ b/packages/docs/api-spec/v1.yaml
@@ -25,6 +25,8 @@ tags:
       x-displayName: Publications
     - name: search
       x-displayName: Search
+    - name: schema
+      x-displayName: Schema
     - name: validate
       x-displayName: Validate
 paths:
@@ -582,10 +584,10 @@ paths:
                     description: Bad Request
                 '500':
                     description: Internal Server Error
-    /models/{modelName}/validate:
+    /models/{modelName}/schema:
         get:
             tags:
-                - validate
+                - schema
             summary: get model's schema
             description: Gets the schema for the model to which the document belongs.
             operationId: getDocumentSchema
@@ -603,12 +605,13 @@ paths:
                     description: Not Found
                 '500':
                     description: Internal Server Error
+    /models/{modelName}/validate:
         post:
             tags:
                 - validate
             summary: validate a document against its model's schema
             description: Strictly validate a document againt the schema stored in mEditor for the document's model.
-            operationId: vaidateDocument
+            operationId: validateDocument
             parameters:
                 - name: modelName
                   in: path

--- a/packages/docs/api-spec/v1.yaml
+++ b/packages/docs/api-spec/v1.yaml
@@ -25,6 +25,8 @@ tags:
       x-displayName: Publications
     - name: search
       x-displayName: Search
+    - name: validate
+      x-displayName: Validate
 paths:
     /models:
         get:
@@ -580,3 +582,47 @@ paths:
                     description: Bad Request
                 '500':
                     description: Internal Server Error
+    /models/{modelName}/validate:
+        get:
+            tags:
+                - validate
+            summary: get model's schema
+            description: Gets the schema for the model to which the document belongs.
+            operationId: getDocumentSchema
+            parameters:
+                - name: modelName
+                  in: path
+                  description: name of model
+                  required: true
+                  schema:
+                      type: string
+            responses:
+                '200':
+                    description: OK
+                '404':
+                    description: Not Found
+                '500':
+                    description: Internal Server Error
+        post:
+            tags:
+                - validate
+            summary: validate a document against its model's schema
+            description: Strictly validate a document againt the schema stored in mEditor for the document's model.
+            operationId: vaidateDocument
+            parameters:
+                - name: modelName
+                  in: path
+                  description: name of model
+                  required: true
+                  schema:
+                      type: string
+            requestBody:
+                content:
+                    application/json: {}
+                description: document to validate
+                required: true
+            responses:
+                '200':
+                    description: Success (Validation Passes)
+                '400':
+                    description: Bad Request (Validation Fails)


### PR DESCRIPTION
This PR adds an endpoint that strictly validates a POSTed document against the document's model's schema. To run the unit tests, please run `npm t` in the app directory. To run an end-to-end test, I recommend grabbing a document from mEditor's API or UI, then posting it to the new validate endpoint.