### PR TITLE
fix(nats): only add listeners when NATS client is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.9.13] - 2024 05-29
 
 ### Added
 
 - changelog
+
+### Fixed
+
+- add NATS listeners only when there's not an existing NATS client

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meditor",
-  "version": "1.9.12",
+  "version": "1.9.13",
   "description": "mEditor, the model editor",
   "directories": {
     "example": "examples",

--- a/packages/app/lib/nats.ts
+++ b/packages/app/lib/nats.ts
@@ -10,12 +10,20 @@ async function connectToNats() {
         `Connecting with client ${clientID} to NATS (Cluster: ${clusterID}, Server: ${server})`
     )
 
-    if (!globalThis.natsClient) {
-        globalThis.natsClient = connect(clusterID, clientID, {
-            url: server,
-            maxReconnectAttempts: -1,
-        })
+    if (globalThis.natsClient) {
+        log.debug(`A global NATS client was found; returning early.`)
+
+        return
     }
+
+    log.debug(
+        `A global NATS client was not found; attempting to connect ${clientID} to ${clusterID}.`
+    )
+
+    globalThis.natsClient = connect(clusterID, clientID, {
+        url: server,
+        maxReconnectAttempts: -1,
+    })
 
     // close connection when API shuts down
     process.on('SIGTERM', event => {


### PR DESCRIPTION
This PR changes our NATS lib so that we only add event listeners if the NATS client is not found.