### PR TITLE
Feature/meditor 857 add bulk selection of documents

### DIFF
--- a/packages/app/components/search/search-list.module.css
+++ b/packages/app/components/search/search-list.module.css
@@ -28,3 +28,13 @@
 .grid > div:nth-child(5) {
     justify-self: center;
 }
+
+.select {
+    display: flex;
+    align-items: center;
+}
+
+.select > input {
+    margin-right: 10px;
+    margin-bottom: 7px;
+}

--- a/packages/app/components/search/search-list.tsx
+++ b/packages/app/components/search/search-list.tsx
@@ -39,6 +39,7 @@ const SearchList = ({
 }: SearchListProps) => {
     const [currentPage, setCurrentPage] = useState(0)
     const [localDocuments, setLocalDocuments] = useState([])
+    const [selectedDocuments, setSelectedDocuments] = useState([])
 
     const itemsPerPage = 50
     const offset = currentPage * itemsPerPage
@@ -91,6 +92,22 @@ const SearchList = ({
         )
     }
 
+    const toggleDocumentSelection = title => {
+        setSelectedDocuments(prevSelected =>
+            prevSelected.includes(title)
+                ? prevSelected.filter(docTitle => docTitle !== title)
+                : [...prevSelected, title]
+        )
+    }
+
+    const toggleAllSelection = () => {
+        if (listDocuments.length === selectedDocuments.length) {
+            setSelectedDocuments([])
+        } else {
+            setSelectedDocuments(documents.map(doc => doc.title))
+        }
+    }
+
     return (
         <div>
             <SearchStatusBar
@@ -102,6 +119,14 @@ const SearchList = ({
                 user={user}
                 searchOptions={searchOptions}
                 onFilterChange={onFilterChange}
+            />
+            <input
+                type="checkbox"
+                checked={
+                    listDocuments.length > 0 &&
+                    listDocuments.length === selectedDocuments.length
+                }
+                onChange={toggleAllSelection}
             />
 
             {listDocuments.length > 0 && (
@@ -132,6 +157,10 @@ const SearchList = ({
                                         document={document}
                                         modelName={model.name}
                                         onCloned={onRefreshList}
+                                        selectedDocuments={selectedDocuments}
+                                        toggleDocumentSelection={
+                                            toggleDocumentSelection
+                                        }
                                     />
                                 )
                             }

--- a/packages/app/components/search/search-list.tsx
+++ b/packages/app/components/search/search-list.tsx
@@ -123,13 +123,14 @@ const SearchList = ({
             <div className={styles.select}>
                 <input
                     type="checkbox"
+                    id="select-all-checkbox"
                     checked={
                         listDocuments.length > 0 &&
                         listDocuments.length === selectedDocuments.length
                     }
                     onChange={toggleAllSelection}
                 />
-                <label>Select All</label>
+                <label htmlFor="select-all-checkbox">Select All</label>
             </div>
 
             {listDocuments.length > 0 && (

--- a/packages/app/components/search/search-list.tsx
+++ b/packages/app/components/search/search-list.tsx
@@ -120,14 +120,17 @@ const SearchList = ({
                 searchOptions={searchOptions}
                 onFilterChange={onFilterChange}
             />
-            <input
-                type="checkbox"
-                checked={
-                    listDocuments.length > 0 &&
-                    listDocuments.length === selectedDocuments.length
-                }
-                onChange={toggleAllSelection}
-            />
+            <div className={styles.select}>
+                <input
+                    type="checkbox"
+                    checked={
+                        listDocuments.length > 0 &&
+                        listDocuments.length === selectedDocuments.length
+                    }
+                    onChange={toggleAllSelection}
+                />
+                <label>Select All</label>
+            </div>
 
             {listDocuments.length > 0 && (
                 <div className={styles.grid}>
@@ -148,6 +151,10 @@ const SearchList = ({
                                         isLocalDocument={true}
                                         modelName={model.name}
                                         onDelete={refreshLocalDocuments}
+                                        selectedDocuments={selectedDocuments}
+                                        toggleDocumentSelection={
+                                            toggleDocumentSelection
+                                        }
                                     />
                                 )
                             } else {

--- a/packages/app/components/search/search-result.module.css
+++ b/packages/app/components/search/search-result.module.css
@@ -18,6 +18,10 @@
     justify-content: center;
 }
 
-.result > div > input {
+.result > div > div > input {
     margin-right: 10px;
+}
+
+.result > div > div > label{
+    visibility: hidden;
 }

--- a/packages/app/components/search/search-result.module.css
+++ b/packages/app/components/search/search-result.module.css
@@ -17,3 +17,7 @@
 .result > div:last-child {
     justify-content: center;
 }
+
+.result > div > input {
+    margin-right: 10px;
+}

--- a/packages/app/components/search/search-result.module.css
+++ b/packages/app/components/search/search-result.module.css
@@ -22,6 +22,6 @@
     margin-right: 10px;
 }
 
-.result > div > div > label{
+.result > div > div > label {
     visibility: hidden;
 }

--- a/packages/app/components/search/search-result.module.css
+++ b/packages/app/components/search/search-result.module.css
@@ -22,6 +22,14 @@
     margin-right: 10px;
 }
 
-.result > div > div > label {
-    visibility: hidden;
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }

--- a/packages/app/components/search/search-result.tsx
+++ b/packages/app/components/search/search-result.tsx
@@ -62,6 +62,10 @@ const SearchResult = ({
                             checked={selectedDocuments.includes(document.localId)}
                             onChange={() => toggleDocumentSelection(document.localId)}
                         />
+                        <label
+                            className="visually-hidden"
+                            htmlFor={document.localId}
+                        ></label>
                         <label htmlFor={document.localId}></label>
                     </div>
                 )}
@@ -73,6 +77,10 @@ const SearchResult = ({
                             checked={selectedDocuments.includes(document.title)}
                             onChange={() => toggleDocumentSelection(document.title)}
                         />
+                        <label
+                            className="visually-hidden"
+                            htmlFor={document.title}
+                        ></label>
                         <label htmlFor={document.title}></label>
                     </div>
                 )}

--- a/packages/app/components/search/search-result.tsx
+++ b/packages/app/components/search/search-result.tsx
@@ -55,18 +55,26 @@ const SearchResult = ({
         <div className={styles.result}>
             <div>
                 {isLocalDocument && (
+                    <div>
                     <input
+                        id={document.localId}
                         type="checkbox"
                         checked={selectedDocuments.includes(document.localId)}
                         onChange={() => toggleDocumentSelection(document.localId)}
                     />
+                    <label htmlFor={document.localId}></label>
+                    </div>
                 )}
                 {!isLocalDocument && (
+                    <div>
                     <input
+                        id={document.title}
                         type="checkbox"
                         checked={selectedDocuments.includes(document.title)}
                         onChange={() => toggleDocumentSelection(document.title)}
                     />
+                    <label htmlFor={document.title}></label>
+                    </div>
                 )}
                 <Link
                     href={

--- a/packages/app/components/search/search-result.tsx
+++ b/packages/app/components/search/search-result.tsx
@@ -56,24 +56,24 @@ const SearchResult = ({
             <div>
                 {isLocalDocument && (
                     <div>
-                    <input
-                        id={document.localId}
-                        type="checkbox"
-                        checked={selectedDocuments.includes(document.localId)}
-                        onChange={() => toggleDocumentSelection(document.localId)}
-                    />
-                    <label htmlFor={document.localId}></label>
+                        <input
+                            id={document.localId}
+                            type="checkbox"
+                            checked={selectedDocuments.includes(document.localId)}
+                            onChange={() => toggleDocumentSelection(document.localId)}
+                        />
+                        <label htmlFor={document.localId}></label>
                     </div>
                 )}
                 {!isLocalDocument && (
                     <div>
-                    <input
-                        id={document.title}
-                        type="checkbox"
-                        checked={selectedDocuments.includes(document.title)}
-                        onChange={() => toggleDocumentSelection(document.title)}
-                    />
-                    <label htmlFor={document.title}></label>
+                        <input
+                            id={document.title}
+                            type="checkbox"
+                            checked={selectedDocuments.includes(document.title)}
+                            onChange={() => toggleDocumentSelection(document.title)}
+                        />
+                        <label htmlFor={document.title}></label>
                     </div>
                 )}
                 <Link

--- a/packages/app/components/search/search-result.tsx
+++ b/packages/app/components/search/search-result.tsx
@@ -50,6 +50,8 @@ const SearchResult = ({
     return (
         <div className={styles.result}>
             <div>
+                {isLocalDocument && <input type="checkbox" />}
+                {!isLocalDocument && <input type="checkbox" />}
                 <Link
                     href={
                         isLocalDocument

--- a/packages/app/components/search/search-result.tsx
+++ b/packages/app/components/search/search-result.tsx
@@ -21,6 +21,8 @@ interface SearchResultProps {
     onCloned?: Function
     onDelete?: Function
     isLocalDocument?: boolean
+    selectedDocuments?: any
+    toggleDocumentSelection?: Function
 }
 
 const SearchResult = ({
@@ -29,6 +31,8 @@ const SearchResult = ({
     onCloned,
     onDelete,
     isLocalDocument,
+    selectedDocuments,
+    toggleDocumentSelection,
 }: SearchResultProps) => {
     const { setSuccessNotification } = useContext(AppContext)
     const [showCloneDocumentModal, setShowCloneDocumentModal] = useState(false)
@@ -50,8 +54,20 @@ const SearchResult = ({
     return (
         <div className={styles.result}>
             <div>
-                {isLocalDocument && <input type="checkbox" />}
-                {!isLocalDocument && <input type="checkbox" />}
+                {isLocalDocument && (
+                    <input
+                        type="checkbox"
+                        checked={selectedDocuments.includes(document.localId)}
+                        onChange={() => toggleDocumentSelection(document.localId)}
+                    />
+                )}
+                {!isLocalDocument && (
+                    <input
+                        type="checkbox"
+                        checked={selectedDocuments.includes(document.title)}
+                        onChange={() => toggleDocumentSelection(document.title)}
+                    />
+                )}
                 <Link
                     href={
                         isLocalDocument


### PR DESCRIPTION
This PR contains bulk selection of documents in meditor UI. Please suggest if you think select All should be in different place. To test visit localhost/meditor and select any document. it should have checkbox next to each document and select all should be visible to select all documents.