### PR TITLE
feat(ckeditor): disable version checks; lock version to last open-sou…

### DIFF
--- a/packages/app/components/jsonschemaform/widgets/CKEditorWidget.tsx
+++ b/packages/app/components/jsonschemaform/widgets/CKEditorWidget.tsx
@@ -77,6 +77,7 @@ function CKEditorWidget(props: WidgetProps) {
                 event.editor.setReadOnly(props.readonly || false)
             }}
             onBeforeLoad={CKEDITOR => {
+                CKEDITOR.config.versionCheck = false
                 CKEDITOR.disableAutoInline = true
 
                 registerPluginsWithCkEditorInstance(CKEDITOR)

--- a/packages/app/package-lock.json
+++ b/packages/app/package-lock.json
@@ -16,7 +16,7 @@
                 "@yaireo/tagify": "3.8.0",
                 "bootstrap": "^4.5.0",
                 "brace": "^0.11.1",
-                "ckeditor4-react": "^4.0.0",
+                "ckeditor4-react": "4.3.0",
                 "cookie-parser": "^1.4.5",
                 "cookies-next": "^2.1.1",
                 "dagre": "^0.8.5",
@@ -4329,9 +4329,9 @@
             "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
         },
         "node_modules/ckeditor4": {
-            "version": "4.20.1",
-            "resolved": "https://registry.npmjs.org/ckeditor4/-/ckeditor4-4.20.1.tgz",
-            "integrity": "sha512-OywaO5CC6n5NcY98Fi4Llc/h9rgmn8uHwEIfWxulVKpu0UCdL8x9p6xCfo/ZfgQN6FTS/eZcP7XzKMuokRN+mQ==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/ckeditor4/-/ckeditor4-4.24.0.tgz",
+            "integrity": "sha512-ShtIqZMMNmP5r8AhZqnysSaONsx+qKjI/zf5AkU9wKxl0yHVw2/CSxWYmdd40u3dMjJR2kOthQ6USahz528lbw==",
             "peer": true
         },
         "node_modules/ckeditor4-integrations-common": {
@@ -4340,15 +4340,15 @@
             "integrity": "sha512-OAoQT/gYrHkg0qgzf6MS/rndYhq3SScLVQ3rtXQeuCE8ju7nFHg3qZ7WGA2XpFxcZzsMP6hhugXqdel5vbcC3g=="
         },
         "node_modules/ckeditor4-react": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-4.1.1.tgz",
-            "integrity": "sha512-iIq/14gXD6+l/+S+urt9oErhyh7/NrFiDqpcsxnmTmA5MVlnjTgmBZg0ik5bWjr0a4Q979opwm39lCq8/Go+wA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-4.3.0.tgz",
+            "integrity": "sha512-pLeh39AHj8jfhQ2SsVy29tklAnwaaSdw5UYZ4HECNTHb1M4dGgTKa6Uy2fqceMnmX5c2G8Ewz9X9tMCLpgZ70w==",
             "dependencies": {
                 "ckeditor4-integrations-common": "^1.0.0",
                 "prop-types": "^15.8.1"
             },
             "peerDependencies": {
-                "ckeditor4": "^4.20.1",
+                "ckeditor4": "^4.22.1",
                 "react": "^18"
             }
         },
@@ -13845,9 +13845,9 @@
             "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
         },
         "ckeditor4": {
-            "version": "4.20.1",
-            "resolved": "https://registry.npmjs.org/ckeditor4/-/ckeditor4-4.20.1.tgz",
-            "integrity": "sha512-OywaO5CC6n5NcY98Fi4Llc/h9rgmn8uHwEIfWxulVKpu0UCdL8x9p6xCfo/ZfgQN6FTS/eZcP7XzKMuokRN+mQ==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/ckeditor4/-/ckeditor4-4.24.0.tgz",
+            "integrity": "sha512-ShtIqZMMNmP5r8AhZqnysSaONsx+qKjI/zf5AkU9wKxl0yHVw2/CSxWYmdd40u3dMjJR2kOthQ6USahz528lbw==",
             "peer": true
         },
         "ckeditor4-integrations-common": {
@@ -13856,9 +13856,9 @@
             "integrity": "sha512-OAoQT/gYrHkg0qgzf6MS/rndYhq3SScLVQ3rtXQeuCE8ju7nFHg3qZ7WGA2XpFxcZzsMP6hhugXqdel5vbcC3g=="
         },
         "ckeditor4-react": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-4.1.1.tgz",
-            "integrity": "sha512-iIq/14gXD6+l/+S+urt9oErhyh7/NrFiDqpcsxnmTmA5MVlnjTgmBZg0ik5bWjr0a4Q979opwm39lCq8/Go+wA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ckeditor4-react/-/ckeditor4-react-4.3.0.tgz",
+            "integrity": "sha512-pLeh39AHj8jfhQ2SsVy29tklAnwaaSdw5UYZ4HECNTHb1M4dGgTKa6Uy2fqceMnmX5c2G8Ewz9X9tMCLpgZ70w==",
             "requires": {
                 "ckeditor4-integrations-common": "^1.0.0",
                 "prop-types": "^15.8.1"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -21,7 +21,7 @@
         "@yaireo/tagify": "3.8.0",
         "bootstrap": "^4.5.0",
         "brace": "^0.11.1",
-        "ckeditor4-react": "^4.0.0",
+        "ckeditor4-react": "4.3.0",
         "cookie-parser": "^1.4.5",
         "cookies-next": "^2.1.1",
         "dagre": "^0.8.5",


### PR DESCRIPTION
…rce release

CKEditor React @4.3.0 uses the last open-source version of CKEditor @4.22.0 / 4.22.1:
- https://www.npmjs.com/package/ckeditor4-react#getting-ckeditor-4-open-source
- https://github.com/ckeditor/ckeditor4/blob/master/CHANGES.md#ckeditor-4220--4221

This commit locks our version of CKEditor React to 4.3.0 and disables further version checks for CKEditor via the versionCheck config option: https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-versionCheck

re MEDITOR-873