### PR TITLE
feat(rjsf): add anchor widget with find-and-replace capabilities

### DIFF
--- a/packages/app/components/jsonschemaform/widgets/AnchorWidget.tsx
+++ b/packages/app/components/jsonschemaform/widgets/AnchorWidget.tsx
@@ -1,0 +1,44 @@
+import type { WidgetProps } from '@rjsf/utils'
+import { useEffect, useState } from 'react'
+import { findAndReplace, macros } from './utils'
+
+/**
+ * Schema Layout:
+    "MyProperty": {
+        "ui:widget": "anchor",
+        "ui:options": {
+            "href": "http://localhost:8080/service-request-from-config?variable_entry_id=******",
+            "text": "",
+            "change": {
+                "every": "***",
+                "to": ["FIELD_LOOKUP:EntryID", "FIELD_LOOKUP:VariableEntryID"] // replace with no regex, not replaceAll, is used. This means you can stack "every" to replace per "to" field.
+            } 
+        }
+    },
+ */
+export default function AnchorWidget({ options }: WidgetProps) {
+    const [href, setHref] = useState(options.href as string)
+
+    useEffect(() => {
+        // @ts-expect-error
+        if (!!options.change.every) {
+            setHref(
+                findAndReplace(
+                    options.href as string,
+                    // @ts-expect-error
+                    options.change.every as string,
+                    // @ts-expect-error
+                    options.change.to as string[],
+                    macros
+                )
+            )
+        }
+        // @ts-expect-error
+    }, [options.href, options.change.every, options.change.to, setHref])
+
+    return (
+        <a href={href} target="_blank" rel="noopener noreferrer">
+            {options.text || href}
+        </a>
+    )
+}

--- a/packages/app/components/jsonschemaform/widgets/ConcatenatedWidget.tsx
+++ b/packages/app/components/jsonschemaform/widgets/ConcatenatedWidget.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react'
 import type { WidgetProps } from '@rjsf/utils'
 import { getTemplate } from '@rjsf/utils'
+import { ID_PREFIX } from './constants'
 
 const DEFAULT_DELIMETER = ' > '
-const ID_PREFIX = 'root_'
 
 export default function ConcatenatedWidget(props: WidgetProps) {
     const BaseInput = getTemplate('BaseInputTemplate', props.registry)

--- a/packages/app/components/jsonschemaform/widgets/__tests__/anchor-widget.test.ts
+++ b/packages/app/components/jsonschemaform/widgets/__tests__/anchor-widget.test.ts
@@ -1,0 +1,97 @@
+import { findAndReplace } from '../utils'
+
+/**
+    "href": "http://localhost:8080/service-request-from-config?variable_entry_id=******",
+    "text": "",
+    "change": {
+        "every": "***",
+        "to": ["FIELD_LOOKUP:EntryID", "FIELD_LOOKUP:VariableEntryID"] // replace with no regex, not replaceAll, is used. This means you can stack "every" to replace per "to" field.
+    } 
+  */
+describe(`RJSF Widgets`, () => {
+    describe(`findAndReplace`, () => {
+        const sourceString =
+            'http://localhost:8080/service-request-from-config?variable_entry_id=***'
+        const every = '***'
+        const to = ['a-variable-entry-id']
+        const macros = {
+            FIELD_LOOKUP: () => 'this value was returned',
+        } as const
+
+        test(`replaces a single instance with a single value, no macro`, () => {
+            const value = findAndReplace(sourceString, every, to, macros)
+
+            expect(value).toMatchInlineSnapshot(
+                `"http://localhost:8080/service-request-from-config?variable_entry_id=a-variable-entry-id"`
+            )
+        })
+
+        test(`can repeat multiple replacement for multiple matches`, () => {
+            const sourceString =
+                'http://localhost:***/service-request-from-config?variable_entry_id=******'
+            const to = ['8080', 'foo', 'bar']
+            const value = findAndReplace(sourceString, every, to, macros)
+
+            expect(value).toMatchInlineSnapshot(
+                `"http://localhost:8080/service-request-from-config?variable_entry_id=foobar"`
+            )
+        })
+
+        test(`can use macros`, () => {
+            // Our FIELD_LOOKUP macro does nothing but return a string, unlike the real macro.
+            const to = ['FIELD_LOOKUP']
+            const value = findAndReplace(sourceString, every, to, macros)
+
+            expect(value).toMatchInlineSnapshot(
+                `"http://localhost:8080/service-request-from-config?variable_entry_id=this value was returned"`
+            )
+        })
+
+        test(`will throw if macro does not have a handler`, () => {
+            const to = ['NOT_A_HANDLED_MACRO']
+            const macros = {
+                NOT_A_HANDLED_MACRO: () => `this doesn't have a handler`,
+            } as const
+
+            expect(() => {
+                findAndReplace(sourceString, every, to, macros)
+            }).toThrowErrorMatchingInlineSnapshot(
+                `"Handler does not yet have a case to handle this macro: NOT_A_HANDLED_MACRO"`
+            )
+        })
+
+        test(`will match per "to" entry found, but no further`, () => {
+            const value = findAndReplace(sourceString, every, to, macros)
+
+            expect(value).toMatchInlineSnapshot(
+                `"http://localhost:8080/service-request-from-config?variable_entry_id=a-variable-entry-id"`
+            )
+        })
+
+        test(`will not replace on empty "to" arrays`, () => {
+            const to = []
+            const value = findAndReplace(sourceString, every, to, macros)
+
+            expect(value).toMatchInlineSnapshot(
+                `"http://localhost:8080/service-request-from-config?variable_entry_id=***"`
+            )
+        })
+
+        test(`will not replace on empty "every" string`, () => {
+            const every = ''
+            const value = findAndReplace(sourceString, every, to, macros)
+
+            expect(value).toMatchInlineSnapshot(
+                `"a-variable-entry-idhttp://localhost:8080/service-request-from-config?variable_entry_id=***"`
+            )
+        })
+
+        test(`returns unmodified source string when no matches are found`, () => {
+            const sourceString =
+                'http://localhost:8080/service-request-from-config?variable_entry_id=^^^'
+            const value = findAndReplace(sourceString, every, to, macros)
+
+            expect(value).toEqual(sourceString)
+        })
+    })
+})

--- a/packages/app/components/jsonschemaform/widgets/constants.ts
+++ b/packages/app/components/jsonschemaform/widgets/constants.ts
@@ -1,0 +1,3 @@
+const ID_PREFIX = 'root_'
+
+export { ID_PREFIX }

--- a/packages/app/components/jsonschemaform/widgets/index.ts
+++ b/packages/app/components/jsonschemaform/widgets/index.ts
@@ -7,6 +7,7 @@ import DateTimeWidget from './DateTimeWidget'
 import ConcatenatedWidget from './ConcatenatedWidget'
 import HtmlTextWidget from './HtmlTextWidget'
 import TitlePropertyWidget from './TitlePropertyWidget'
+import AnchorWidget from './AnchorWidget'
 
 const widgets: RegistryWidgetsType = {
     ckeditor: CKEditorWidget,
@@ -17,6 +18,7 @@ const widgets: RegistryWidgetsType = {
     concatenated: ConcatenatedWidget,
     htmltext: HtmlTextWidget,
     titleproperty: TitlePropertyWidget,
+    anchor: AnchorWidget,
 }
 
 export default widgets

--- a/packages/app/components/jsonschemaform/widgets/utils.ts
+++ b/packages/app/components/jsonschemaform/widgets/utils.ts
@@ -1,0 +1,47 @@
+import { ID_PREFIX } from './constants'
+
+const macros = {
+    FIELD_LOOKUP: (name: string) => {
+        let el = document.getElementById(`${ID_PREFIX}${name}`) as HTMLInputElement
+        // This may be run before the element has been rendered to the DOM, so don't return `undefined`.
+        const value = el.value ?? ''
+
+        return globalThis.encodeURIComponent(value)
+    },
+} as const
+
+function findAndReplace(
+    sourceString: string = '',
+    every: string = '',
+    to: string[] = [],
+    macros: Record<string, Function> = {}
+) {
+    // Starting from the source string, iterate through every entry in "to", replacing with either a macro's return value or a value.
+    return to.reduce((accumulator, current) => {
+        // We may have a MACRO_NAME:FieldName combo, or we may have a value.
+        const [macroNameOrValue, maybeFieldName] = current.split(':')
+        const maybeMacro = macros[macroNameOrValue]
+
+        if (maybeMacro) {
+            // We know we have a macro now.
+            const macroName = macroNameOrValue
+            const fieldName = maybeFieldName
+
+            switch (macroName) {
+                case 'FIELD_LOOKUP':
+                    const replacementValue = macros[macroName](fieldName)
+
+                    return accumulator.replace(every, replacementValue)
+
+                default:
+                    throw Error(
+                        `Handler does not yet have a case to handle this macro: ${macroName}`
+                    )
+            }
+        } else {
+            return accumulator.replace(every, current)
+        }
+    }, sourceString)
+}
+
+export { findAndReplace, macros }


### PR DESCRIPTION
This RJSF widget was made for the Test Configuration model (currently only in UAT mEditor). I'll include the entire model schema you'll need, below. 

### To manually test this, please 
1. use the model schema below
2. copy the Test Configuration model to your locally-running mEditor instance
3. create at least one Test Configuration entry

### To run the unit tests
1. cd `packages/app`
2. `npm t

### Test Configuration Model Schema (not just the RJSF schema and layout)
```json
{
  "icon": {
    "name": "fa-code",
    "color": "#46f0f0"
  },
  "titleProperty": "VariableEntryID",
  "category": "Configuration",
  "workflow": "Edit",
  "name": "Test Configuration",
  "description": "Test Cases for GDDS and Cloud Giovanni",
  "schema": "{\n    \"$schema\": \"http://json-schema.org/schema#\",\n    \"type\": \"object\",\n    \"properties\": {\n        \"RunURL\": {\n          \"title\": \"Generated URL for running this test suite.\",\n          \"description\": \"If the UTF is running on your machine, this URL will trigger all Test Cases in this configuration\",\n          \"type\": \"string\"\n        },\n        \"VariableEntryID\": {\n            \"title\": \"Associated Variable Entry ID\",\n            \"description\": \"The Entry ID for a variable should be CollectionEntryID_VariableShortName.\",\n            \"type\": \"string\"\n        },\n        \"EntryID\": {\n            \"type\": \"object\",\n            \"properties\": {\n                \"CollectionEntryID\": {\n                    \"title\": \"Associated Collection Entry ID\",\n                    \"description\": \"The Entry ID of the collection that the variable is associated with.  The enum is made up of all possible GES DISC collections in the mEditor database, similar to Related Datasets in other UUI content types.\",\n                    \"type\": \"string\",\n                    \"enum\": [\"placeholder\"]\n                },\n                \"ShortName\": {\n                    \"title\": \"Variable Short Name\",\n                    \"description\": \"The variable short name, which corresponds to CMR's Name field.\",\n                    \"type\": \"string\",\n                    \"minLength\": 1,\n                    \"maxLength\": 256\n                }\n            },\n            \"required\": [\"CollectionEntryID\", \"ShortName\"]\n        },\n        \"TestCases\": {\n            \"type\": \"array\",\n            \"title\": \"Test Cases\",\n            \"description\": \"List of test cases associated with an VariableEntryID\",\n            \"items\": {\n                \"type\": \"object\",\n                \"properties\": {\n                    \"Provider\": {\n                        \"description\": \"Collection provider.\",\n                        \"type\": \"string\",\n                        \"default\": \"GES_DISC\",\n                        \"minLength\": 1,\n                        \"maxLength\": 256\n                    },\n                    \"Bounding_Box\": {\n                        \"description\": \"Bounding box subsetting format\",\n                        \"type\": \"object\",\n                        \"properties\": {\n                            \"Southernmost_Latitude\": {\n                                \"type\": \"number\",\n                                \"minimum\": -90,\n                                \"maximum\": 90\n                            },\n                            \"Westernmost_Longitude\": {\n                                \"type\": \"number\",\n                                \"minimum\": -180,\n                                \"maximum\": 180\n                            },\n                            \"Northernmost_Latitude\": {\n                                \"type\": \"number\",\n                                \"minimum\": -90,\n                                \"maximum\": 90\n                            },\n                            \"Easternmost_Longitude\": {\n                                \"type\": \"number\",\n                                \"minimum\": -180,\n                                \"maximum\": 180\n                            }\n                        }\n                    },\n                    \"Time_Bounds\": {\n                        \"description\": \"Temporal range in ISO8601 format\",\n                        \"type\": \"object\",\n                        \"properties\": {\n                            \"Start_Time\": {\n                                \"description\": \"Temporal range start in ISO8601 format.\",\n                                \"type\": \"string\",\n                                \"format\": \"date-time\"\n                            },\n                            \"End_Time\": {\n                                \"description\": \"Temporal range end in ISO8601 format.\",\n                                \"type\": \"string\",\n                                \"format\": \"date-time\"\n                            }\n                        }\n                    },\n                    \"Services\": {\n                        \"description\": \"Service to be tested and compared\",\n                        \"type\": \"object\",\n                        \"properties\": {\n                            \"ServiceA\": {\n                                \"description\": \"Service to be tested and compared with service B.\",\n                                \"type\": \"string\",\n                                \"enum\": [\"goss\", \"hoss\", \"gl2ss\", \"hl2ss\"]\n                            },\n                            \"ServiceB\": {\n                                \"description\": \"Service to be tested and compared with service A.\",\n                                \"type\": \"string\",\n                                \"enum\": [\"goss\", \"hoss\", \"gl2ss\", \"hl2ss\"]\n                            }\n                        }\n                    },\n                    \"Environments\": {\n                        \"description\": \"Service environment\",\n                        \"type\": \"object\",\n                        \"properties\": {\n                            \"EnvironmentA\": {\n                                \"description\": \"Service environment.\",\n                                \"type\": \"string\",\n                                \"enum\": [\"prod\", \"uat\"]\n                            },\n                            \"EnvironmentB\": {\n                                \"description\": \"Service environment.\",\n                                \"type\": \"string\",\n                                \"enum\": [\"prod\", \"uat\"]\n                            }\n                        }\n                    }\n                },\n                \"required\": [\"Bounding_Box\", \"Provider\", \"Services\", \"Environments\"]\n            }\n        }\n    },\n    \"required\": [\"VariableEntryID\", \"EntryID\", \"TestCases\"]\n}",
  "layout": "{\n    \"ui:order\": [\"RunURL\", \"VariableEntryID\", \"*\"],\n    \"RunURL\": {\n        \"ui:widget\": \"anchor\",\n        \"ui:options\": {\n            \"href\": \"http://localhost:8080/service-request-from-config?variable_entry_id=******\",\n            \"text\": \"\",\n            \"change\": {\n                \"every\": \"***\",\n                \"to\": [\"FIELD_LOOKUP:EntryID\", \"FIELD_LOOKUP:VariableEntryID\"]\n              }\n        }\n    },\n    \"VariableEntryID\": {\n        \"ui:widget\": \"concatenated\",\n        \"ui:options\": {\n            \"fields\": [\"EntryID_CollectionEntryID\", \"EntryID_ShortName\"],\n            \"delimeter\": \"_\"\n        }\n    },\n    \"EntryID\": {\n        \"CollectionEntryID\": {\n            \"ui:widget\": \"multi-select\"\n        }\n    }\n}",
  "templates": [
    {
      "jsonpath": "$.properties.EntryID.properties.CollectionEntryID.enum",
      "macro": "list Collection%20Metadata.Combined_EntryID"
    }
  ]
}
```