### PR TITLE
Resolve XSS issue with notebooks

### DIFF
--- a/packages/docs/api-spec/v1.yaml
+++ b/packages/docs/api-spec/v1.yaml
@@ -665,7 +665,7 @@ paths:
                     description: Bad Request
                 '500':
                     description: Internal Server Error
-                    
+
     /models/{modelName}/schema:
         get:
             tags:

--- a/packages/notebook-viewer/app.py
+++ b/packages/notebook-viewer/app.py
@@ -34,6 +34,10 @@ def convertNotebookToHtml():
     
     # if we're including a github.com URL, we'll provide some additional links to the original github repo
     if notebookUrl.startswith('https://github.com'):
+        # make sure we are only rendering notebooks from the nasa organization
+        if not notebookUrl.startswith('https://github.com/nasa/'):
+            return "Invalid notebook URL, must be in the NASA organization", 400
+
         githubUrl = notebookUrl
         notebookUrl = notebookUrl.replace(
             "https://github.com", "https://raw.githubusercontent.com").replace("/blob/", "/")


### PR DESCRIPTION
Should only be able to load Jupyter Notebooks from the NASA Github organization

This notebook which contains a XSS script (that just console.logs) should throw an error:
http://localhost/meditor/notebookviewer?notebookUrl=https://github.com/joncarlson/vuln/blob/main/xss.ipynb

This should render without issue, note that it is from the NASA organization:
http://localhost/meditor/notebookviewer/?notebookUrl=https://github.com/nasa/gesdisc-tutorials/blob/main/cloud-tutorials/notebooks/How_to_Access_and_Analyze_GLDAS_Zarr_Stores.ipynb