### PR TITLE
Only build the app at build-time, not run-time

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,3 @@
-version: "3.3"
-
 services:
   notebookviewer:
     container_name: meditor_notebookviewer
@@ -37,6 +35,7 @@ services:
     volumes:
       - ./packages/app:/usr/src/app
       - /usr/src/app/node_modules
+      - /usr/src/app/.next
 
   docs:
     container_name: meditor_docs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.3"
-
 services:
   notebookviewer:
     depends_on:

--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -9,13 +9,14 @@ WORKDIR /usr/src/app
 COPY package*.json ./
 RUN npm install
 COPY . .
+RUN npm run build
 
 EXPOSE 3000
 EXPOSE 4000
 
 CMD if [ "$NODE_ENV" = "production" ]; \
   then \
-  npm run build && npm run start; \
+  npm run start; \
   else \
   npm run dev; \
   fi


### PR DESCRIPTION
This is to remove the building of the meditor_app image in production.

To test:

- On your local machine, remove the packages/app/.next folder as well as the meditor_app Docker image (docker image rm CONTAINER_ID)
- make sure your .env file, in the root project folder, is using NODE_ENV=production
- `docker compose build`
- `docker compose up`

mEditor should startup without issue