### PR TITLE
Feature/meditor 896 show collaborators for given document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0] - 2024-09-19
+
+### Added
+
+- Added feature for seeing other collaborators on a given document.
+
 ## [1.10.0] - 2024-06-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meditor",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "mEditor, the model editor",
   "directories": {
     "example": "examples",

--- a/packages/app/auth/db.ts
+++ b/packages/app/auth/db.ts
@@ -1,5 +1,4 @@
 import type { Db } from 'mongodb'
-import type { Document } from '../documents/types'
 import getDb, { makeSafeObjectIDs } from '../lib/mongodb'
 import type { Model, ModelWithWorkflow } from '../models/types'
 import type { UserContactInformation } from './types'

--- a/packages/app/collaboration/adapters.ts
+++ b/packages/app/collaboration/adapters.ts
@@ -1,0 +1,23 @@
+import type { User } from 'auth/types'
+import type { Collaborator } from './types'
+
+export function adaptUserToCollaborator(
+    user: User,
+    privileges: Collaborator['privileges'],
+    hasBeenActive: Collaborator['hasBeenActive'],
+    isActive: Collaborator['isActive']
+): Collaborator {
+    const { firstName, lastName, uid } = user
+    const [firstNameInitial] = firstName.split('')
+    const [lastNameInitial] = lastName.split('')
+
+    return {
+        firstName,
+        hasBeenActive,
+        initials: `${firstNameInitial}${lastNameInitial}`,
+        isActive,
+        lastName,
+        privileges,
+        uid,
+    }
+}

--- a/packages/app/collaboration/db.ts
+++ b/packages/app/collaboration/db.ts
@@ -1,0 +1,93 @@
+import type { Collaborator } from './types'
+import type { Db } from 'mongodb'
+import getDb, { makeSafeObjectIDs } from '../lib/mongodb'
+import { ErrorCode, HttpException } from 'utils/errors'
+
+class CollaboratorsDb {
+    #COLLECTION = 'Collaborators'
+    #db: Db
+    #durationSeconds = 60 * 10
+    #indexName = 'active_collaborators'
+
+    async connect(connectDb: () => Promise<Db>) {
+        if (!this.#db) {
+            this.#db = await connectDb()
+        }
+    }
+
+    /**
+     * Collaborator documents are set to expire with a TTL index. This means that MongoDB handles removing stale collaborators. To stay unexpired, collaborator records must be updated more frequently than the TTL.
+     * In MongoDB ^4.12.1, creating an index requires that the collection already exist. Unlike other update operations, this does not happen automatically.
+     */
+    async maybeCreateTTLIndex() {
+        const indices = await this.#db.collection(this.#COLLECTION).indexes()
+        const index = indices.find(index => {
+            return index.name === this.#indexName
+        })
+
+        if (!index) {
+            await this.#db.collection(this.#COLLECTION).createIndex(
+                { updatedAt: 1 },
+                {
+                    expireAfterSeconds: this.#durationSeconds,
+                    name: this.#indexName,
+                }
+            )
+        }
+    }
+
+    async upsertDocumentCollaborator(
+        collaborator: Collaborator,
+        documentTitle: string,
+        modelName: string
+    ) {
+        const query = { uid: collaborator.uid }
+        const operation = {
+            $set: {
+                documentModelTitle: `${modelName}_${documentTitle}`,
+                firstName: collaborator.firstName,
+                hasBeenActive: collaborator.hasBeenActive,
+                initials: collaborator.initials,
+                isActive: collaborator.isActive,
+                lastName: collaborator.lastName,
+                uid: collaborator.uid,
+                updatedAt: new Date(),
+            },
+        }
+
+        const { modifiedCount, upsertedCount } = await this.#db
+            .collection(this.#COLLECTION)
+            .updateOne(query, operation, { upsert: true })
+
+        if (!(modifiedCount || upsertedCount)) {
+            throw new HttpException(
+                ErrorCode.InternalServerError,
+                'Failed to update the collaborator.'
+            )
+        }
+
+        await this.maybeCreateTTLIndex()
+        return await this.getDocumentCollaborators(documentTitle, modelName)
+    }
+
+    async getDocumentCollaborators(documentTitle: string, modelName: string) {
+        const query = { documentModelTitle: `${modelName}_${documentTitle}` }
+
+        const results = await this.#db
+            .collection(this.#COLLECTION)
+            .find(query)
+            .toArray()
+
+        return makeSafeObjectIDs(results) ?? []
+    }
+}
+
+const db = new CollaboratorsDb()
+
+async function getCollaboratorsDb() {
+    await db.connect(getDb)
+
+    return db
+}
+
+export { getCollaboratorsDb }

--- a/packages/app/collaboration/http.ts
+++ b/packages/app/collaboration/http.ts
@@ -1,0 +1,30 @@
+import type { APIError, ErrorData } from '../declarations'
+import { ErrorCode, HttpException } from '../utils/errors'
+import type { Collaborator } from './types'
+
+export async function updateCollaborators(
+    collaborator: Collaborator,
+    documentTitle: string,
+    modelName: string
+): Promise<ErrorData<Collaborator[]>> {
+    try {
+        const response = await fetch(
+            `/meditor/api/collaboration/models/${encodeURIComponent(
+                modelName
+            )}/documents/${encodeURIComponent(documentTitle)}`,
+            { body: JSON.stringify(collaborator), method: 'POST' }
+        )
+
+        if (!response.ok) {
+            const { error }: APIError = await response.json()
+
+            throw new HttpException(ErrorCode.InternalServerError, error)
+        }
+
+        const collaborators = await response.json()
+
+        return [null, collaborators]
+    } catch (error) {
+        return [error, null]
+    }
+}

--- a/packages/app/collaboration/lib.ts
+++ b/packages/app/collaboration/lib.ts
@@ -1,0 +1,9 @@
+import type { User } from 'auth/types'
+import type { Collaborator } from './types'
+
+export function filterActiveUser(
+    collaborators: Collaborator[] = [],
+    activeUser: User
+) {
+    return collaborators.filter(collaborator => collaborator.uid !== activeUser.uid)
+}

--- a/packages/app/collaboration/schema.ts
+++ b/packages/app/collaboration/schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+
+const collaborationInputSchema = z.object({
+    firstName: z.string().min(1),
+    hasBeenActive: z.boolean(),
+    initials: z.string().length(2),
+    isActive: z.boolean(),
+    lastName: z.string().min(1),
+    privileges: z.array(z.string()),
+    uid: z.string().min(2),
+})
+
+export { collaborationInputSchema }

--- a/packages/app/collaboration/service.ts
+++ b/packages/app/collaboration/service.ts
@@ -1,0 +1,56 @@
+import type { ErrorData } from 'declarations'
+import { parseZodAsErrorData } from 'utils/errors'
+import { getCollaboratorsDb } from './db'
+import { collaborationInputSchema } from './schema'
+import type { Collaborator } from './types'
+
+export async function getDocumentCollaborators(
+    documentTitle: string,
+    modelName: string
+): Promise<ErrorData<Collaborator[]>> {
+    try {
+        const collaboratorsDb = await getCollaboratorsDb()
+
+        const results = await collaboratorsDb.getDocumentCollaborators(
+            documentTitle,
+            modelName
+        )
+
+        return [null, results]
+    } catch (error) {
+        return [error, null]
+    }
+}
+
+export async function setDocumentCollaborator(
+    collaborator: Collaborator,
+    documentTitle: string,
+    modelName: string
+): Promise<ErrorData<Collaborator[]>> {
+    try {
+        const [parsingError, parsedCollaborator] = parseZodAsErrorData<Collaborator>(
+            collaborationInputSchema,
+            collaborator
+        )
+
+        if (parsingError) {
+            throw parsingError
+        }
+
+        // This condition is not an error, just business logic: if the user doesn't have edit permissions for the document they are not a collaborator.
+        if (!parsedCollaborator.privileges.includes('edit')) {
+            return await getDocumentCollaborators(documentTitle, modelName)
+        }
+        const collaboratorsDb = await getCollaboratorsDb()
+
+        const results = await collaboratorsDb.upsertDocumentCollaborator(
+            parsedCollaborator,
+            documentTitle,
+            modelName
+        )
+
+        return [null, results]
+    } catch (error) {
+        return [error, null]
+    }
+}

--- a/packages/app/collaboration/types.ts
+++ b/packages/app/collaboration/types.ts
@@ -1,0 +1,12 @@
+import type { User } from 'auth/types'
+import type { ObjectId } from 'mongodb'
+
+export type Collaborator = {
+    firstName: User['firstName']
+    hasBeenActive: boolean
+    initials: string
+    isActive: boolean
+    lastName: User['lastName']
+    privileges: string[]
+    uid: User['uid']
+}

--- a/packages/app/components/document/document-header.module.css
+++ b/packages/app/components/document/document-header.module.css
@@ -1,8 +1,21 @@
+.header {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.titleDescription {
+    flex: 1 1 auto;
+}
+
 .title {
     align-items: center;
     display: flex;
     font-size: 24px;
     font-weight: 500;
+}
+
+.title h2 {
+    margin-block: 0;
 }
 
 .title span {
@@ -17,12 +30,47 @@
 
 .description {
     color: rgba(0, 0, 0, 0.54);
+    flex: 1 0 100%;
     margin-top: 5px;
 }
 
-.subheader {
-    display: flex;
+.collaborators {
     align-items: center;
+    block-size: 4em;
+    display: flex;
+    flex-wrap: nowrap;
+    flex: 0 1 auto;
+    gap: 1em;
+    justify-content: flex-start;
+    max-inline-size: 23rem;
+}
+
+.collaborator {
+    align-items: center;
+    block-size: 3em;
+    border-radius: 50%;
+    border: 0.25em solid #e0e0e0;
+    display: flex;
+    flex: 0 0 auto;
+    font-size: 1.25rem;
+    font-weight: 500;
+    inline-size: 3em;
+    justify-content: center;
+    letter-spacing: 0.125rem;
+}
+
+.collaborator[data-has-been-active='true'] {
+    border-color: #6c757d;
+}
+
+.collaborator[data-is-active='true'] {
+    border-color: #007bff;
+}
+
+.subheader {
+    align-items: center;
+    display: flex;
+    flex: 1 0 100%;
     margin-top: 20px;
 }
 

--- a/packages/app/components/document/document-header.tsx
+++ b/packages/app/components/document/document-header.tsx
@@ -14,17 +14,17 @@ import styles from './document-header.module.css'
 import DocumentStateBadge from './document-state-badge'
 
 type PropsType = {
-    activePanel: string
-    document: Document
-    isJsonPanelOpen: boolean
-    model: ModelWithWorkflow
-    version: any
-    toggleJsonDiffer: () => void
-    togglePanelOpen: (panel: string) => void
-    privileges: string[]
-    comments: DocumentComment[]
-    history: DocumentHistory[]
-    collaborators: Collaborator[]
+    activePanel?: string
+    document?: Document
+    isJsonPanelOpen?: boolean
+    model?: ModelWithWorkflow
+    version?: any
+    toggleJsonDiffer?: () => void
+    togglePanelOpen?: (panel: string) => void
+    privileges?: string[]
+    comments?: DocumentComment[]
+    history?: DocumentHistory[]
+    collaborators?: Collaborator[]
 }
 
 const DocumentHeader = ({
@@ -33,8 +33,8 @@ const DocumentHeader = ({
     isJsonPanelOpen = false,
     model,
     version = null,
-    toggleJsonDiffer,
-    togglePanelOpen,
+    toggleJsonDiffer = () => {},
+    togglePanelOpen = () => {},
     privileges = [],
     comments = [],
     history = [],

--- a/packages/app/pages/[modelName]/[documentTitle]/index.tsx
+++ b/packages/app/pages/[modelName]/[documentTitle]/index.tsx
@@ -269,7 +269,7 @@ const EditDocumentPage = ({
         refreshDataInPlace(router)
     }
 
-    function togglePanel(panel) {
+    function togglePanel(panel: string) {
         setActivePanel(panel === activePanel ? null : panel)
     }
 

--- a/packages/app/pages/[modelName]/new/index.tsx
+++ b/packages/app/pages/[modelName]/new/index.tsx
@@ -149,7 +149,7 @@ const NewDocumentPage = ({ user, model }: NewDocumentPageProps) => {
                 <Breadcrumb title="New" />
             </Breadcrumbs>
 
-            <DocumentHeader model={model} togglePanelOpen toggleJsonDiffer />
+            <DocumentHeader model={model} />
 
             <Form
                 model={model}

--- a/packages/app/pages/api/collaboration/index.ts
+++ b/packages/app/pages/api/collaboration/index.ts
@@ -1,0 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    switch (req.method) {
+        default:
+            return res.status(405).end()
+    }
+}

--- a/packages/app/pages/api/collaboration/models/[modelName]/documents/[documentTitle]/index.ts
+++ b/packages/app/pages/api/collaboration/models/[modelName]/documents/[documentTitle]/index.ts
@@ -1,0 +1,74 @@
+import { getLoggedInUser } from 'auth/user'
+import {
+    getDocumentCollaborators,
+    setDocumentCollaborator,
+} from 'collaboration/service'
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { respondAsJson } from 'utils/api'
+import { apiError, ErrorCode, HttpException } from 'utils/errors'
+import { safeParseJSON } from 'utils/json'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    const modelName = decodeURIComponent(req.query.modelName.toString())
+    const documentTitle = decodeURIComponent(req.query.documentTitle.toString())
+    const user = await getLoggedInUser(req, res)
+
+    switch (req.method) {
+        case 'GET': {
+            // Unlike most GET endpoints, unauthenticated users should not have access to an authenicated user's actions.
+            if (!user) {
+                return apiError(
+                    new HttpException(ErrorCode.Unauthorized, 'Unauthorized'),
+                    res
+                )
+            }
+
+            const [error, collaborators] = await getDocumentCollaborators(
+                documentTitle,
+                modelName
+            )
+
+            if (error) {
+                return apiError(error, res)
+            }
+
+            return respondAsJson(collaborators, req, res)
+        }
+
+        case 'POST': {
+            if (!user) {
+                return apiError(
+                    new HttpException(ErrorCode.Unauthorized, 'Unauthorized'),
+                    res
+                )
+            }
+
+            const [parseError, collaborator] = safeParseJSON(req.body)
+
+            if (parseError) {
+                return apiError(
+                    new HttpException(
+                        ErrorCode.BadRequest,
+                        'The request body could not be parsed.'
+                    ),
+                    res
+                )
+            }
+
+            const [error, collaborators] = await setDocumentCollaborator(
+                collaborator,
+                documentTitle,
+                modelName
+            )
+
+            if (error) {
+                return apiError(error, res)
+            }
+
+            return respondAsJson(collaborators, req, res, { httpStatusCode: 201 })
+        }
+
+        default:
+            return res.status(405).end()
+    }
+}

--- a/packages/app/pages/api/collaboration/models/[modelName]/documents/index.ts
+++ b/packages/app/pages/api/collaboration/models/[modelName]/documents/index.ts
@@ -1,0 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    switch (req.method) {
+        default:
+            return res.status(405).end()
+    }
+}

--- a/packages/app/pages/api/collaboration/models/[modelName]/index.ts
+++ b/packages/app/pages/api/collaboration/models/[modelName]/index.ts
@@ -1,0 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    switch (req.method) {
+        default:
+            return res.status(405).end()
+    }
+}


### PR DESCRIPTION
## Purpose

This PR adds the ability to see collaborators on a given unique document (model name + document title). 

- Only users with `edit` privileges are considered collaborators.
- Collaborators have UI for `isActive` (blue), `hasBeenActive` (dark grey), whose states are determined by `globalThis.navigator.userActivation` ([docs](https://developer.mozilla.org/en-US/docs/Web/API/UserActivation)). If neither are true (I opened the page but never interacted with it), a tertiary stale UI state (light grey) is shown.
- Collaborators are removed after 10 minutes of inactivity (they are no longer have a UI element representing them on the page). E.g., I'm editing a page, but then leave it. My browser may put the tab into "sleep mode" and stop sending updates. After 10 minutes, I'd no longer be considered a collaborator, and the UI for my user as a collaborator would disappear. Another example: I leave the page open and my browser doesn't suspend the tab. Because it is still sending requests to the collaborator API, I will still be shown as a collaborator. Let's discuss this if there's something more optimal that we could do!
- I used the `title` attribute to show additional information about each collaborator: full name, description of what the UI state means.
- Even if you're not an editor for a given document, you will still see collaborators.
- Four collaborators will be displayed at a time, with up to nine additional collaborators being put into a `+n` UI component. If there are more than nine additional collaborators, the UI component displays `++`.
- Collaborators are sorted by state, so active collaborators show up first, followed by inactive collaborators, followed by collaborators who haven't yet interacted with the page.

## Testing

I owe some tests for this; I built this feature in the tail end of an IP sprint. 

- Run the existing tests to see if I've broken anything.
- Find someone (or lots of people) who have edit privileges (maybe some who don't) and visit a document.

## Visual Changes

I don't have a screenshot at the moment, but collaborators will show up in the document's header towards the right.