### PR TITLE
fix(datetimewidget): fix broken onBlur event handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.1] - 2024-09-30
+
+### Fixed
+
+- `DateTimeWidget` now registers input through keyboard (typing, copy/paste).
+
 ## [1.10.0] - 2024-06-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meditor",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "mEditor, the model editor",
   "directories": {
     "example": "examples",

--- a/packages/app/components/jsonschemaform/widgets/DateTimeWidget.tsx
+++ b/packages/app/components/jsonschemaform/widgets/DateTimeWidget.tsx
@@ -3,6 +3,23 @@ import Flatpickr from 'react-flatpickr'
 import { format, zonedTimeToUtc } from 'date-fns-tz'
 import type { WidgetProps } from '@rjsf/utils'
 
+function formatDate(date: string, dateFormatOption: any) {
+    let dateValue
+
+    switch (dateFormatOption) {
+        case 'Z':
+            dateValue = zonedTimeToUtc(new Date(date), 'Etc/UTC').toISOString()
+            break
+
+        default:
+            dateValue = format(new Date(date), 'yyyy-MM-dd HH:mm:ssxxx')
+
+            break
+    }
+
+    return dateValue
+}
+
 function DateTimeWidget(props: WidgetProps) {
     const {
         id,
@@ -28,25 +45,15 @@ function DateTimeWidget(props: WidgetProps) {
             disabled={disabled || readonly}
             autoFocus={autofocus || false}
             defaultValue={value}
-            onBlur={() => {
-                onBlur(id, value)
-            }}
-            onChange={(_selectedDates, date) => {
-                let dateValue
-
-                switch (dateFormatOption) {
-                    case 'Z':
-                        dateValue = zonedTimeToUtc(
-                            new Date(date),
-                            'Etc/UTC'
-                        ).toISOString()
-                        break
-
-                    default:
-                        dateValue = format(new Date(date), 'yyyy-MM-dd HH:mm:ssxxx')
+            onBlur={(event: any) => {
+                // @rsjf (or maybe our onBlur function) does not correctly handle the blur event for this component.
+                // Instead of onBlur, call onChange if there's a value.
+                if (event.target.value) {
+                    onChange(formatDate(event.target.value, dateFormatOption))
                 }
-
-                onChange(dateValue)
+            }}
+            onChange={(_selectedDates: any, date: string) => {
+                onChange(formatDate(date, dateFormatOption))
             }}
             options={{
                 time_24hr: true,


### PR DESCRIPTION
@rsjf (or our `onBlur` function) did not correctly handle the onBlur event--the input's value would not save to form state. `onBlur` now calls @rsjf's native `onChange` event.

fix #53470