### PR TITLE
Meditor 910 history reporting incorrectly

### DIFF
--- a/packages/app/components/document/document-history.module.css
+++ b/packages/app/components/document/document-history.module.css
@@ -52,7 +52,6 @@
 }
 
 .pastState {
-    color: grey;
     display: flex;
     padding-top: 10px;
     padding-left: 20px;
@@ -78,7 +77,6 @@
 
 .pastState:first-child:before {
     content: '';
-    border-left: 1px solid grey;
     position: absolute;
     top: -4px;
     height: 20px;
@@ -89,10 +87,24 @@
     display: none;
 }
 
-.pastState svg {
+.dotCircleIcon {
     position: absolute;
     top: 10px;
     left: 0;
+    color: grey;
+}
+
+.arrowRightIcon {
+    color: grey;
+    margin: 0 3px;
+}
+
+.stateTransition{
+    margin-bottom: 4px;
+}
+
+.stateModifier {
+    color: grey;
 }
 
 .activeHistory {

--- a/packages/app/components/document/document-history.module.css
+++ b/packages/app/components/document/document-history.module.css
@@ -99,7 +99,7 @@
     margin: 0 3px;
 }
 
-.stateTransition{
+.stateTransition {
     margin-bottom: 4px;
 }
 

--- a/packages/app/components/document/document-history.tsx
+++ b/packages/app/components/document/document-history.tsx
@@ -1,6 +1,6 @@
 import Button from 'react-bootstrap/Button'
 import Card from 'react-bootstrap/Card'
-import { FaRegDotCircle } from 'react-icons/fa'
+import { FaRegDotCircle, FaArrowRight } from 'react-icons/fa'
 import { IoMdEye, IoMdEyeOff } from 'react-icons/io'
 import { useLocalStorage } from '../../lib/use-localstorage.hook'
 import styles from './document-history.module.css'
@@ -13,16 +13,30 @@ const sortByLastModifiedDesc = (a, b) => {
     return dateA > dateB ? -1 : dateA < dateB ? 1 : 0
 }
 
+const formatDate = (date) => {
+    date = new Date(date)
+
+    // Format the date to a more readable format
+    const formattedDate = date.toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    });
+    return formattedDate
+}
+
 const PastState = ({ state }) => (
     <div className={styles.pastState}>
         <div>
-            <FaRegDotCircle />
-
+            <FaRegDotCircle className={styles.dotCircleIcon}/>
             <div>
-                <div>{state.source}</div>
-                <div>
+                <div className={styles.stateTransition}>{state.source}  <FaArrowRight className={styles.arrowRightIcon}/>  {state.target}</div>
+                <div className={styles.stateModifier}>
                     <em>
-                        {state.modifiedBy} on {state.modifiedOn}
+                        {state.modifiedBy} on {formatDate(state.modifiedOn)}
                     </em>
                 </div>
             </div>
@@ -39,7 +53,7 @@ const DocumentHistory = ({
     const [historyPreferences, setHistoryPreferences] = useLocalStorage(
         'historyPreferences',
         {
-            showDetails: false,
+            showDetails: true,      // Initial value if historyPreferences.showDetails not set on local storage.
         }
     )
 
@@ -112,7 +126,7 @@ const DocumentHistory = ({
                         <Card.Body>
                             <div className={styles.body}>
                                 <div className={styles.meta}>
-                                    <a>{item.modifiedOn}</a>
+                                    <a>{formatDate(item.modifiedOn)}</a>
                                     {item.modifiedBy}
                                 </div>
 
@@ -130,7 +144,6 @@ const DocumentHistory = ({
                                     }`}
                                 >
                                     {item.states
-                                        ?.sort(sortByLastModifiedDesc)
                                         .map(state => (
                                             <PastState
                                                 state={state}

--- a/packages/app/components/document/document-history.tsx
+++ b/packages/app/components/document/document-history.tsx
@@ -7,33 +7,37 @@ import styles from './document-history.module.css'
 import DocumentStateBadge from './document-state-badge'
 
 const sortByLastModifiedDesc = (a, b) => {
+    // Used to sort the history details in descending order. NO LONGER USED
     let dateA = new Date(a.modifiedOn)
     let dateB = new Date(b.modifiedOn)
 
     return dateA > dateB ? -1 : dateA < dateB ? 1 : 0
 }
 
-const formatDate = (date) => {
+const formatDate = date => {
     date = new Date(date)
 
     // Format the date to a more readable format
-    const formattedDate = date.toLocaleString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    });
+    const formattedDate = date.toLocaleString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+    })
     return formattedDate
 }
 
 const PastState = ({ state }) => (
     <div className={styles.pastState}>
         <div>
-            <FaRegDotCircle className={styles.dotCircleIcon}/>
+            <FaRegDotCircle className={styles.dotCircleIcon} />
             <div>
-                <div className={styles.stateTransition}>{state.source}  <FaArrowRight className={styles.arrowRightIcon}/>  {state.target}</div>
+                <div className={styles.stateTransition}>
+                    {state.source} <FaArrowRight className={styles.arrowRightIcon} />{' '}
+                    {state.target}
+                </div>
                 <div className={styles.stateModifier}>
                     <em>
                         {state.modifiedBy} on {formatDate(state.modifiedOn)}
@@ -53,7 +57,7 @@ const DocumentHistory = ({
     const [historyPreferences, setHistoryPreferences] = useLocalStorage(
         'historyPreferences',
         {
-            showDetails: true,      // Initial value if historyPreferences.showDetails not set on local storage.
+            showDetails: true, // Initial value if historyPreferences.showDetails not set on local storage.
         }
     )
 
@@ -143,13 +147,12 @@ const DocumentHistory = ({
                                             : ''
                                     }`}
                                 >
-                                    {item.states
-                                        .map(state => (
-                                            <PastState
-                                                state={state}
-                                                key={state.source + state.modifiedOn}
-                                            />
-                                        ))}
+                                    {item.states.map(state => (
+                                        <PastState
+                                            state={state}
+                                            key={state.source + state.modifiedOn}
+                                        />
+                                    ))}
                                 </div>
                             )}
                         </Card.Body>

--- a/packages/app/documents/service.ts
+++ b/packages/app/documents/service.ts
@@ -95,12 +95,16 @@ export async function createDocument(
         }
 
         //* This logic (and associated TODO) is ported from Meditor.js, saveDocument. Minimal modifications were made.
-        const modDate = new Date().toISOString()
+        const modifiedDate = new Date().toISOString()
 
         //* Create the INITAL state history for a NEW document or an Edited/Saved document which creates a new DB object of the document.
-        const rootState = { source: INIT_STATE, target: initialState, modifiedOn: modDate }
+        const rootState = {
+            source: INIT_STATE,
+            target: initialState,
+            modifiedOn: modifiedDate,
+        }
 
-        document['x-meditor'].modifiedOn = modDate
+        document['x-meditor'].modifiedOn = modifiedDate
         document['x-meditor'].modifiedBy = user.uid
         // TODO: replace with actual model init state
         document['x-meditor'].states = [rootState]

--- a/packages/app/documents/service.ts
+++ b/packages/app/documents/service.ts
@@ -64,7 +64,7 @@ export async function createDocument(
             )
         }
 
-        // validate that there is at least one edge going from "Init" to to the initialState
+        // validate that there is at least one edge going from "Init" to the initialState
         if (
             !workflow.edges.some(
                 edge => edge.source === INIT_STATE && edge.target === initialState
@@ -95,11 +95,12 @@ export async function createDocument(
         }
 
         //* This logic (and associated TODO) is ported from Meditor.js, saveDocument. Minimal modifications were made.
-        const rootState = { source: INIT_STATE, target: initialState }
+        const modDate = new Date().toISOString()
 
-        // @ts-ignore
-        rootState.modifiedOn = document['x-meditor'].modifiedOn
-        document['x-meditor'].modifiedOn = new Date().toISOString()
+        //* Create the INITAL state history for a NEW document or an Edited/Saved document which creates a new DB object of the document.
+        const rootState = { source: INIT_STATE, target: initialState, modifiedOn: modDate }
+
+        document['x-meditor'].modifiedOn = modDate
         document['x-meditor'].modifiedBy = user.uid
         // TODO: replace with actual model init state
         document['x-meditor'].states = [rootState]


### PR DESCRIPTION
Fix null modifiedOn date for initial document state. Improve history detail layout in the history panel for readability. History issues are still a potential problem when users "edit"/"save"/"submit for review" from a browser window that is not refreshed and current with any new status changes. 