### PR TITLE
Bugfix/users can not add roles unless author access

### DIFF
--- a/packages/app/auth/db.ts
+++ b/packages/app/auth/db.ts
@@ -76,19 +76,19 @@ class UsersDb {
     }
 
     async createUserAccount(userContactInformation: UserContactInformation) {
-        return await this.#db
-            .collection<Document>(this.#ACCOUNTS_COLLECTION)
-            .updateOne(
-                {
-                    uid: userContactInformation.uid,
-                },
-                {
-                    $set: userContactInformation,
-                },
-                {
-                    upsert: true,
-                }
-            )
+        await this.#db.collection<Document>(this.#ACCOUNTS_COLLECTION).updateOne(
+            {
+                uid: userContactInformation.uid,
+            },
+            {
+                $set: userContactInformation,
+            },
+            {
+                upsert: true,
+            }
+        )
+
+        return this.getMeditorUserByUid(userContactInformation.uid)
     }
 
     async getMeditorUserByUid(uid: string): Promise<Document> {

--- a/packages/app/documents/service.ts
+++ b/packages/app/documents/service.ts
@@ -44,6 +44,16 @@ export async function createDocument(
     initialState: string = DRAFT_STATE // the initial state the document will be created in
 ): Promise<ErrorData<{ insertedDocument: Document; location: string }>> {
     try {
+        assert(user, new createError.Unauthorized('User is not authenticated'))
+
+        const userRolesForModel = findAllowedUserRolesForModel(modelName, user?.roles)
+
+        assert(
+            userRolesForModel.length > 0,
+            new createError.Forbidden(
+                `User does not have any roles for model "${modelName}"`
+            )
+        )
         const { _id, ...document } = documentToCreate // remove the database _id property
 
         const documentsDb = await getDocumentsDb()

--- a/packages/app/pages/api/auth/[...nextauth].ts
+++ b/packages/app/pages/api/auth/[...nextauth].ts
@@ -144,8 +144,12 @@ export const authOptions: AuthOptions = {
             }
 
             const usersDb = await getUsersDb()
-            await usersDb.createUserAccount(mapSessionToUser(session))
-            return true // expects a bool, whether user can sign in or not
+            const userAccount = await usersDb.createUserAccount(
+                mapSessionToUser(session)
+            )
+
+            // allow sign in if the user has any roles
+            return userAccount?.roles?.length // expects a bool, whether user can sign in or not
         },
         async session({ session, token }) {
             // add user uid to the session


### PR DESCRIPTION
This PR includes a fix for mEditor security issue. When creating a document users are being authenticated if they have any role for that model or not. Users are not allowed to create a document if they do not have assigned role for that model.
Also block anonymous logins.