### PR TITLE
Hide the 'clone' action if user does not have permission based on mod…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,13 @@
 {
   "name": "meditor",
-  "version": "1.10.0",
-  "lockfileVersion": 1
+  "version": "1.22.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "meditor",
+      "version": "1.22.1",
+      "license": "MIT"
+    }
+  }
 }

--- a/packages/app/components/search/search-list.tsx
+++ b/packages/app/components/search/search-list.tsx
@@ -139,6 +139,7 @@ const SearchList = ({
                             if (document.localId) {
                                 return (
                                     <SearchResult
+                                        model={model}
                                         key={document.localId}
                                         document={document}
                                         isLocalDocument={true}
@@ -153,6 +154,7 @@ const SearchList = ({
                             } else {
                                 return (
                                     <SearchResult
+                                        model={model}
                                         key={document.title}
                                         document={document}
                                         modelName={model.name}

--- a/packages/app/components/search/search-result.tsx
+++ b/packages/app/components/search/search-result.tsx
@@ -11,11 +11,14 @@ import type { Document } from '../../documents/types'
 import { AppContext } from '../app-store'
 import CloneDocumentModal from '../document/clone-document-modal'
 import DocumentStateBadge from '../document/document-state-badge'
+import { privilegesForModelAndWorkflowNode, rolesForModel } from 'auth/utilities'
+import { useSession } from 'next-auth/react'
 import IconButton from '../icon-button'
 import StateBadge from '../state-badge'
 import styles from './search-result.module.css'
 
 interface SearchResultProps {
+    model: any // what is the type of model here?
     document: Document | UnsavedDocument
     modelName: string
     onCloned?: Function
@@ -26,6 +29,7 @@ interface SearchResultProps {
 }
 
 const SearchResult = ({
+    model,
     document,
     modelName,
     onCloned,
@@ -36,6 +40,13 @@ const SearchResult = ({
 }: SearchResultProps) => {
     const { setSuccessNotification } = useContext(AppContext)
     const [showCloneDocumentModal, setShowCloneDocumentModal] = useState(false)
+    const { data: session, status } = useSession()
+
+    const currentPrivileges = privilegesForModelAndWorkflowNode(
+        session?.user,
+        modelName.toString(),
+        model.workflow.currentNode
+    )
 
     function removeUnsavedDocument() {
         if (
@@ -123,7 +134,7 @@ const SearchResult = ({
                     </IconButton>
                 )}
 
-                {!isLocalDocument && (
+                {!isLocalDocument && currentPrivileges.includes('create') && (
                     <IconButton
                         alt="Clone Document"
                         onClick={() => setShowCloneDocumentModal(true)}

--- a/packages/app/pages/api/auth/[...nextauth].ts
+++ b/packages/app/pages/api/auth/[...nextauth].ts
@@ -147,9 +147,15 @@ export const authOptions: AuthOptions = {
             const userAccount = await usersDb.createUserAccount(
                 mapSessionToUser(session)
             )
+            const canSignIn = userAccount?.roles?.length > 0
 
             // allow sign in if the user has any roles
-            return userAccount?.roles?.length // expects a bool, whether user can sign in or not
+            if (userAccount != null)
+                // if we got a mEditor user account back, enforce role requirement for sign in
+                return canSignIn
+            else {
+                return true // if no mEditor user account already exists, allow sign in in via EarthData.
+            }
         },
         async session({ session, token }) {
             // add user uid to the session


### PR DESCRIPTION
Changed code to hide the 'clone' action if user does not have permission based on model type.  Also had to resolve a user authentication situation that Denied Access to mEditor when user has not yet established a mEditor account with roles.  

To test, determine which models you do not have privileges to create. Open the list view for that model type and verify you do not see a Clone button in the Action column.  For models you do have create permissions, the clone action should be available.